### PR TITLE
Fix CLI connection failures and add Windows compatibility

### DIFF
--- a/extension/src/discovery.ts
+++ b/extension/src/discovery.ts
@@ -14,6 +14,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import * as crypto from 'crypto'
+import { execSync } from 'child_process'
 import { HOOK_TIMEOUT_S, HOOK_SAFETY_MARGIN_MS, HOOK_FORWARD_TIMEOUT_MS, WORKSPACE_HASH_LENGTH } from './constants'
 import { createLogger } from './logger'
 
@@ -26,10 +27,44 @@ const WORKSPACES_MANIFEST_PATH = path.join(DISCOVERY_DIR, 'workspaces.json')
 /** Identifier substring used to detect our command hooks in settings.json */
 export const HOOK_COMMAND_MARKER = 'agent-flow/hook.js'
 
-export function getHookCommand(): string { return `node "${HOOK_SCRIPT_PATH}"` }
+/** Resolve the absolute path to the `node` binary.
+ *  VS Code's extension host runs in Electron, so process.execPath is not node.
+ *  We shell out to `command -v node` (POSIX) or `where node` (Windows) using
+ *  the VS Code environment's PATH which typically has node available. */
+let cachedNodePath: string | null = null
+function resolveNodePath(): string {
+  if (cachedNodePath) return cachedNodePath
+  try {
+    const cmd = process.platform === 'win32' ? 'where node' : 'command -v node'
+    const result = execSync(cmd, { encoding: 'utf8', timeout: 3000 }).trim()
+    // `where` on Windows may return multiple lines — use the first
+    const firstLine = result.split(/\r?\n/)[0].trim()
+    if (firstLine) {
+      cachedNodePath = firstLine
+      log.info(`Resolved node path: ${cachedNodePath}`)
+      return cachedNodePath
+    }
+  } catch (err) {
+    log.debug('Failed to resolve absolute node path, falling back to bare "node":', err)
+  }
+  cachedNodePath = 'node'
+  return cachedNodePath
+}
+
+export function getHookCommand(): string {
+  const nodePath = resolveNodePath()
+  return `"${nodePath}" "${HOOK_SCRIPT_PATH}"`
+}
+
+/** Resolve and normalize a path, following symlinks where possible. */
+function normalizePath(p: string): string {
+  let resolved = path.resolve(p)
+  try { resolved = fs.realpathSync(resolved) } catch { /* use path.resolve result if realpathSync fails */ }
+  return resolved
+}
 
 export function hashWorkspace(workspace: string): string {
-  return crypto.createHash('sha256').update(path.resolve(workspace)).digest('hex').slice(0, WORKSPACE_HASH_LENGTH)
+  return crypto.createHash('sha256').update(normalizePath(workspace)).digest('hex').slice(0, WORKSPACE_HASH_LENGTH)
 }
 
 // ─── Discovery Files ──────────────────────────────────────────────────────────
@@ -41,7 +76,7 @@ export function writeDiscoveryFile(port: number, workspace: string): void {
   fs.writeFileSync(filePath, JSON.stringify({
     port,
     pid: process.pid,
-    workspace: path.resolve(workspace),
+    workspace: normalizePath(workspace),
   }, null, 2) + '\n')
   log.info(`Wrote ${filePath}`)
 }
@@ -62,7 +97,7 @@ export function removeDiscoveryFile(workspace: string): void {
 
 export function addWorkspaceToManifest(workspace: string): void {
   ensureDir()
-  const resolved = path.resolve(workspace)
+  const resolved = normalizePath(workspace)
   const workspaces = readManifest()
   if (workspaces.includes(resolved)) { return }
   workspaces.push(resolved)
@@ -108,17 +143,19 @@ function ensureDir(): void {
 
 function getHookScriptContent(): string {
   return `#!/usr/bin/env node
-// Agent Flow hook forwarder v2 — installed by the Agent Flow VS Code extension.
+// Agent Flow hook forwarder v3 — installed by the Agent Flow VS Code extension.
 // Claude Code invokes this as a command hook. It reads a discovery directory to
 // find live extension instances, checks their PIDs, and forwards the event via
 // HTTP POST. Dead instances are cleaned up automatically.
+//
+// v3: containment-based workspace matching (supports subdirectory CWD),
+//     realpathSync normalization (handles symlinks), Windows-safe PID checks.
 //
 // Discovery dir: ~/.claude/agent-flow/
 // Discovery file: {workspace-hash}-{pid}.json  →  { port, pid, workspace }
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const crypto = require('crypto');
 const http = require('http');
 const os = require('os');
 
@@ -128,6 +165,22 @@ const os = require('os');
 setTimeout(() => process.exit(0), ${HOOK_TIMEOUT_S * 1000 - HOOK_SAFETY_MARGIN_MS});
 
 const DIR = path.join(os.homedir(), '.claude', 'agent-flow');
+const IS_WIN = process.platform === 'win32';
+
+/** Normalize a path: resolve and follow symlinks where possible */
+function normPath(p) {
+  let r = path.resolve(p);
+  try { r = fs.realpathSync(r); } catch {}
+  return r;
+}
+
+/** Check if a process is alive. On Windows, process.kill(pid, 0) is unreliable
+ *  (can throw even for live processes), so we skip the check and let stale
+ *  discovery files be cleaned up by the extension on activation instead. */
+function isAlive(pid) {
+  if (IS_WIN) return true;
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
 
 let input = '';
 process.stdin.setEncoding('utf8');
@@ -137,26 +190,46 @@ process.stdin.on('end', () => {
   try { cwd = JSON.parse(input).cwd; } catch { process.exit(0); }
   if (!cwd) process.exit(0);
 
-  const hash = crypto.createHash('sha256').update(path.resolve(cwd)).digest('hex').slice(0, ${WORKSPACE_HASH_LENGTH});
+  const resolvedCwd = normPath(cwd);
 
-  let files;
+  // Read all discovery files
+  let allFiles;
   try {
-    files = fs.readdirSync(DIR).filter(f => f.startsWith(hash + '-') && f.endsWith('.json'));
+    allFiles = fs.readdirSync(DIR).filter(f => f.endsWith('.json') && f !== 'workspaces.json');
   } catch { process.exit(0); }
-  if (!files.length) process.exit(0);
+  if (!allFiles.length) process.exit(0);
 
-  let pending = 0;
-  for (const file of files) {
+  // Parse discovery files and find workspaces that contain this cwd.
+  // Use longest-match-wins so /project/sub matches before /project.
+  const matches = [];
+  for (const file of allFiles) {
     let d;
     try { d = JSON.parse(fs.readFileSync(path.join(DIR, file), 'utf8')); } catch { continue; }
+    if (!d.workspace || !d.pid || !d.port) continue;
 
-    // Check PID is alive
-    try { process.kill(d.pid, 0); } catch {
+    // Clean up dead instances (skip on Windows where PID check is unreliable)
+    if (!isAlive(d.pid)) {
       try { fs.unlinkSync(path.join(DIR, file)); } catch {}
       continue;
     }
 
-    pending++;
+    // Containment check: is cwd equal to or under this workspace?
+    const ws = normPath(d.workspace);
+    if (resolvedCwd === ws || resolvedCwd.startsWith(ws + path.sep)) {
+      matches.push({ d, file, wsLen: ws.length });
+    }
+  }
+
+  if (!matches.length) process.exit(0);
+
+  // Sort by workspace path length descending — most specific match first
+  matches.sort((a, b) => b.wsLen - a.wsLen);
+  const bestLen = matches[0].wsLen;
+  // Forward to all instances of the best (most specific) workspace match
+  const targets = matches.filter(m => m.wsLen === bestLen);
+
+  let pending = targets.length;
+  for (const { d } of targets) {
     let settled = false;
     const finish = () => { if (settled) return; settled = true; done(); };
     const req = http.request({
@@ -170,7 +243,6 @@ process.stdin.on('end', () => {
     req.end();
   }
 
-  if (!pending) process.exit(0);
   function done() { if (--pending <= 0) process.exit(0); }
 });
 `

--- a/extension/src/event-source.ts
+++ b/extension/src/event-source.ts
@@ -44,7 +44,7 @@ export class JsonlEventSource implements vscode.Disposable {
 
   private processExistingContent(): void {
     const content = fs.readFileSync(this.filePath, 'utf-8')
-    const lines = content.split('\n').filter(Boolean)
+    const lines = content.split(/\r?\n/).filter(Boolean)
     for (const line of lines) {
       const event = this.parseLine(line)
       if (event) {

--- a/extension/src/fs-utils.ts
+++ b/extension/src/fs-utils.ts
@@ -35,6 +35,6 @@ export function readNewFileLines(filePath: string, lastSize: number): { lines: s
   }
 
   const newContent = readFileChunk(filePath, lastSize, stat.size - lastSize)
-  const lines = newContent.split('\n').filter(Boolean)
+  const lines = newContent.split(/\r?\n/).filter(Boolean)
   return { lines, newSize: stat.size }
 }

--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -124,7 +124,21 @@ export class SessionWatcher implements vscode.Disposable {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
     if (workspaceFolder) {
       // Claude Code encodes project paths: /Users/simon/project → -Users-simon-project
-      this.workspacePath = workspaceFolder.replace(/\//g, '-')
+      // Resolve symlinks first, then replace both / and \ (Windows) with -
+      let resolved = workspaceFolder
+      try { resolved = fs.realpathSync(resolved) } catch { /* use original if realpathSync fails */ }
+      const encoded = resolved.replace(/[/\\]/g, '-')
+
+      // Try the resolved encoding first; fall back to unresolved if the directory doesn't exist
+      // (handles edge cases where Claude Code didn't resolve symlinks the same way)
+      const resolvedDir = path.join(CLAUDE_DIR, encoded)
+      if (fs.existsSync(resolvedDir)) {
+        this.workspacePath = encoded
+      } else {
+        const unresolvedEncoded = workspaceFolder.replace(/[/\\]/g, '-')
+        const unresolvedDir = path.join(CLAUDE_DIR, unresolvedEncoded)
+        this.workspacePath = fs.existsSync(unresolvedDir) ? unresolvedEncoded : encoded
+      }
       log.info(`Starting — scoped to project: ${this.workspacePath}`)
     } else {
       log.info('Starting — no workspace, scanning all projects')

--- a/extension/src/subagent-watcher.ts
+++ b/extension/src/subagent-watcher.ts
@@ -104,7 +104,7 @@ function startWatchingSubagentFile(
     const stat = fs.statSync(filePath)
     if (stat.size > 0) {
       const content = fs.readFileSync(filePath, 'utf-8')
-      for (const line of content.split('\n')) {
+      for (const line of content.split(/\r?\n/)) {
         if (!line.trim()) continue
         try {
           const raw: unknown = JSON.parse(line.trim())

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -396,7 +396,7 @@ export class TranscriptParser {
       // Reading beyond would add tool_use IDs to the dedup set that haven't
       // been accounted for in fileSize, causing readNewLines to silently skip them.
       const content = readFileChunk(filePath, 0, size)
-      for (const line of content.split('\n')) {
+      for (const line of content.split(/\r?\n/)) {
         if (!line.trim()) { continue }
         try {
           const entry = JSON.parse(line.trim()) as TranscriptEntry


### PR DESCRIPTION
## What does this PR do?

Fixes three silent failure modes that prevent CLI users from connecting to Agent Flow, and adds Windows compatibility across the extension.

**CLI fixes:**
- **Subdirectory CWD matching** — The hook script now uses containment-based workspace matching (longest-match-wins) instead of exact hash lookup. Running `claude` from a subdirectory of the project now correctly forwards events to the visualizer.
- **Absolute node path** — The hook command now embeds the full path to `node` (e.g. `/Users/x/.nvm/versions/node/v22/bin/node`) instead of bare `node`, so hooks work in terminals without nvm/node on PATH.
- **Symlink normalization** — Discovery files and session watcher resolve symlinks via `realpathSync` before comparing paths.

**Windows fixes:**
- **PID liveness check** — `process.kill(pid, 0)` is unreliable on Windows; the hook script now skips it on Windows and lets the extension clean up stale files on activation.
- **CRLF line splitting** — All JSONL line splitting uses `/\r?\n/` instead of `\n`.
- **Path encoding** — Workspace path encoding now replaces both `/` and `\` separators.

## How to test

**Subdirectory CWD (most impactful):**
1. Open a project in VS Code with Agent Flow active
2. In a standalone terminal, `cd` into a subdirectory of that project
3. Run `claude` — events should appear in the visualizer

**Absolute node path:**
1. Reload VS Code after installing the update
2. Check `~/.claude/settings.json` — hook commands should show a full path to node instead of bare `node`

**Symlink normalization:**
1. Create a symlink to your project: `ln -s /path/to/project /tmp/project-link`
2. Open VS Code via the symlink, run `claude` from the real path — events should connect

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)