### PR TITLE
Fix memory leaks, unbounded map growth, and canvas render overhead

### DIFF
--- a/extension/src/hook-server.ts
+++ b/extension/src/hook-server.ts
@@ -49,8 +49,11 @@ interface HookPayload {
 export class HookServer implements vscode.Disposable {
   private server: http.Server | null = null
   private port: number
-  private sessionStartTimes = new Map<string, number>() // session_id → start timestamp
-  private agentNames = new Map<string, string>() // agent_id → friendly name
+  /** Per-session state — cleaned up on SessionEnd/Stop to prevent unbounded growth */
+  private sessionState = new Map<string, {
+    startTime: number
+    agentNames: Map<string, string> // agent_id → friendly name
+  }>()
 
   private readonly _onEvent = new vscode.EventEmitter<AgentEvent>()
 
@@ -128,8 +131,17 @@ export class HookServer implements vscode.Disposable {
     return this.port
   }
 
+  private getOrCreateSession(sessionId: string): { startTime: number; agentNames: Map<string, string> } {
+    let state = this.sessionState.get(sessionId)
+    if (!state) {
+      state = { startTime: Date.now(), agentNames: new Map() }
+      this.sessionState.set(sessionId, state)
+    }
+    return state
+  }
+
   private elapsedSeconds(sessionId?: string): number {
-    const startTime = sessionId ? (this.sessionStartTimes.get(sessionId) ?? Date.now()) : Date.now()
+    const startTime = sessionId ? (this.sessionState.get(sessionId)?.startTime ?? Date.now()) : Date.now()
     return (Date.now() - startTime) / 1000
   }
 
@@ -169,7 +181,7 @@ export class HookServer implements vscode.Disposable {
   }
 
   private handleSessionStart(payload: HookPayload): void {
-    this.sessionStartTimes.set(payload.session_id, Date.now())
+    this.getOrCreateSession(payload.session_id)
 
     this.emit({
       time: 0,
@@ -188,7 +200,7 @@ export class HookServer implements vscode.Disposable {
     const args = summarizeInput(toolName, payload.tool_input)
 
     // If this is the first event and no session start was received, auto-spawn
-    if (!this.sessionStartTimes.has(payload.session_id)) {
+    if (!this.sessionState.has(payload.session_id)) {
       this.handleSessionStart(payload)
     }
 
@@ -246,9 +258,10 @@ export class HookServer implements vscode.Disposable {
     const parentName = this.resolveAgentName(payload)
     const agentType = payload.agent_type || 'subagent'
     const agentId = payload.agent_id || ''
-    const childName = agentId ? `${agentType}-${agentId.slice(-SUBAGENT_ID_SUFFIX_LENGTH)}` : generateSubagentFallbackName(String(Date.now()), this.agentNames.size + 1)
+    const sessionAgents = this.getOrCreateSession(payload.session_id).agentNames
+    const childName = agentId ? `${agentType}-${agentId.slice(-SUBAGENT_ID_SUFFIX_LENGTH)}` : generateSubagentFallbackName(String(Date.now()), sessionAgents.size + 1)
 
-    this.agentNames.set(agentId, childName)
+    sessionAgents.set(agentId, childName)
 
     emitSubagentSpawn(
       { emit: (e, s) => this.emit(e, s), elapsed: (s) => this.elapsedSeconds(s) },
@@ -258,7 +271,8 @@ export class HookServer implements vscode.Disposable {
 
   private handleSubagentStop(payload: HookPayload): void {
     const agentId = payload.agent_id || ''
-    const childName = this.agentNames.get(agentId) || 'subagent'
+    const sessionAgents = this.sessionState.get(payload.session_id)?.agentNames
+    const childName = sessionAgents?.get(agentId) || 'subagent'
     const parentName = this.resolveAgentName(payload)
 
     this.emit({
@@ -302,14 +316,18 @@ export class HookServer implements vscode.Disposable {
       type: 'agent_complete',
       payload: { name: ORCHESTRATOR_NAME, sessionEnd: true },
     }, payload.session_id)
+
+    // Clean up per-session state to prevent unbounded Map growth
+    this.sessionState.delete(payload.session_id)
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────────────
 
   private resolveAgentName(payload: HookPayload): string {
-    // If this event has an agent_id, use it. Otherwise default to orchestrator.
-    if (payload.agent_id && this.agentNames.has(payload.agent_id)) {
-      return this.agentNames.get(payload.agent_id)!
+    // If this event has an agent_id, look it up in the session's agent names.
+    if (payload.agent_id) {
+      const name = this.sessionState.get(payload.session_id)?.agentNames.get(payload.agent_id)
+      if (name) return name
     }
     return ORCHESTRATOR_NAME
   }
@@ -323,6 +341,7 @@ export class HookServer implements vscode.Disposable {
       this.server.close()
       this.server = null
     }
+    this.sessionState.clear()
     this._onEvent.dispose()
   }
 }

--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -448,6 +448,8 @@ export class SessionWatcher implements vscode.Disposable {
       }
       session.subagentWatchers.clear()
       session.subagentsDirWatcher?.close()
+      // Clean up orphaned parser state for this session
+      this.parser.clearSessionState(session.pendingToolCalls.keys())
     }
     this.sessions.clear()
     if (this.scanInterval) {

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -66,6 +66,15 @@ export class TranscriptParser {
 
   constructor(private delegate: TranscriptParserDelegate) {}
 
+  /** Clean up state associated with a completed session to prevent unbounded Map growth.
+   *  Pass the session's pending tool_use_ids so we can remove orphaned entries. */
+  clearSessionState(pendingToolUseIds: Iterable<string>): void {
+    for (const toolUseId of pendingToolUseIds) {
+      this.inlineSubagentState.delete(toolUseId)
+      this.subagentChildNames.delete(toolUseId)
+    }
+  }
+
   processTranscriptLine(
     line: string,
     agentName = ORCHESTRATOR_NAME,
@@ -77,7 +86,8 @@ export class TranscriptParser {
     let parsed: Record<string, unknown>
     try {
       parsed = JSON.parse(line.trim()) as Record<string, unknown>
-    } catch {
+    } catch (err) {
+      log.debug('Skipping unparseable line:', err)
       return
     }
 

--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -67,6 +67,17 @@ export function AgentCanvas({
   const prevAgentStatesRef = useRef<Map<string, string>>(new Map())
   const prevToolStatesRef = useRef<Map<string, string>>(new Map())
 
+  // Rate-limited error logging for the draw loop (avoid flooding console)
+  const lastDrawErrorRef = useRef(0)
+
+  // Caches for per-frame lookups — avoid rebuilding Set/Map every ~16ms
+  const edgeLookupCacheRef = useRef<{
+    particles: Particle[]
+    edges: Edge[]
+    activeEdgeIds: Set<string>
+    edgeMap: Map<string, Edge>
+  }>({ particles: [], edges: [], activeEdgeIds: new Set(), edgeMap: new Map() })
+
   // ─── Stable refs for animation loop & event handlers ────────────────────
   const makeDrawProps = (prev?: { isDragging: boolean }) => ({
     agents, toolCalls, particles, edges, discoveries,
@@ -141,8 +152,12 @@ export function AgentCanvas({
 
   // ─── Main draw loop ────────────────────────────────────────────────────
 
+  // Stable ref so the rAF loop always calls the latest draw without
+  // re-subscribing when the callback identity changes.
+  const drawRef = useRef<(timestamp: number) => void>(() => {})
+
   const draw = useCallback((timestamp: number) => {
-    animationRef.current = requestAnimationFrame(draw)
+    animationRef.current = requestAnimationFrame((ts) => drawRef.current(ts))
 
     const canvas = mainCanvasRef.current
     if (!canvas) return
@@ -214,9 +229,18 @@ export function AgentCanvas({
     ctx.translate(transform.x, transform.y)
     ctx.scale(transform.scale, transform.scale)
 
-    // Pre-compute shared lookup structures once per frame
-    const activeEdgeIds = getActiveEdgeIds(particles)
-    const edgeMap = buildEdgeMap(edges)
+    // Pre-compute shared lookup structures — cached across frames when inputs are unchanged
+    const elCache = edgeLookupCacheRef.current
+    let activeEdgeIds: Set<string>
+    let edgeMap: Map<string, Edge>
+    if (elCache.particles === particles && elCache.edges === edges) {
+      activeEdgeIds = elCache.activeEdgeIds
+      edgeMap = elCache.edgeMap
+    } else {
+      activeEdgeIds = getActiveEdgeIds(particles)
+      edgeMap = buildEdgeMap(edges)
+      edgeLookupCacheRef.current = { particles, edges, activeEdgeIds, edgeMap }
+    }
 
     drawDiscoveryConnections(ctx, discoveries, agents)
     drawEdges(ctx, edges, agents, toolCalls, activeEdgeIds, timeRef.current)
@@ -237,13 +261,24 @@ export function AgentCanvas({
 
     if (showCostOverlay) drawCostSummaryPanel(ctx, agents, toolCalls)
     if (bloomRef.current) bloomRef.current.apply(canvas, ctx)
-    } catch { /* keep rAF loop alive */ }
+    } catch (err) {
+      // Log at most once every 5s to avoid flooding the console
+      const now = Date.now()
+      if (now - lastDrawErrorRef.current > 5000) {
+        lastDrawErrorRef.current = now
+        console.warn('[AgentCanvas] draw error:', err)
+      }
+    }
   }, [detectStateChanges, updateCamera, updateDragLerp, transformRef])
 
+  drawRef.current = draw
+
   useEffect(() => {
-    animationRef.current = requestAnimationFrame(draw)
+    const loop = (timestamp: number) => drawRef.current(timestamp)
+    animationRef.current = requestAnimationFrame(loop)
     return () => { if (animationRef.current) cancelAnimationFrame(animationRef.current) }
-  }, [draw])
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- drawRef is stable; rAF loop set up once
+  }, [])
 
   return (
     <div ref={containerRef} className="relative w-full h-full overflow-hidden" style={{ cursor: isDragging ? 'grabbing' : 'grab' }}>

--- a/web/components/agent-visualizer/canvas/draw-misc.ts
+++ b/web/components/agent-visualizer/canvas/draw-misc.ts
@@ -34,7 +34,7 @@ export function drawTetherLine(ctx: CanvasRenderingContext2D, agent: Agent, tran
   ctx.globalAlpha = TETHER.alpha
   ctx.strokeStyle = COLORS.holoBase + TETHER.strokeAlpha
   ctx.lineWidth = TETHER.lineWidth
-  ctx.setLineDash(TETHER.dash as unknown as number[])
+  ctx.setLineDash(TETHER.dash)
   ctx.beginPath()
   ctx.moveTo(startX, startY)
   const midX = (startX + endX) / 2

--- a/web/hooks/use-canvas-camera.ts
+++ b/web/hooks/use-canvas-camera.ts
@@ -43,6 +43,16 @@ export function useCanvasCamera({
   const targetTransformRef = useRef<Transform | null>(null)
   const panVelocityRef = useRef({ vx: 0, vy: 0, active: false })
 
+  // Cache for computeFitTransform — avoids O(n) iteration every frame.
+  // Invalidates on collection reference change (React creates new Map/array on state updates).
+  const fitCacheRef = useRef<{
+    agents: Map<string, Agent> | null
+    toolCalls: Map<string, ToolCallNode> | null
+    discoveries: Discovery[] | null
+    selectedAgentId: string | null
+    result: Transform | null
+  }>({ agents: null, toolCalls: null, discoveries: null, selectedAgentId: null, result: null })
+
   // Initialize transform centered on first agents
   useEffect(() => {
     if (agentCount > 0 && transformRef.current.x === 0 && transformRef.current.y === 0) {
@@ -69,6 +79,16 @@ export function useCanvasCamera({
   const computeFitTransform = useCallback((): Transform | null => {
     const { agents, toolCalls, discoveries, dimensions, selectedAgentId } = drawPropsRef.current
     if (agents.size === 0) return null
+
+    // Return cached result if inputs haven't changed (reference equality —
+    // React creates new Map/array objects on state updates, so same ref = same data)
+    const cache = fitCacheRef.current
+    if (cache.agents === agents
+      && cache.toolCalls === toolCalls
+      && cache.discoveries === discoveries
+      && cache.selectedAgentId === selectedAgentId) {
+      return cache.result
+    }
 
     // Determine focus scope: if a non-main agent is selected, focus on it + descendants
     let focusScope: Set<string> | null = null
@@ -119,18 +139,23 @@ export function useCanvasCamera({
         maxY = Math.max(maxY, disc.y + DISC_BOUNDS_HALF_H)
       }
     }
-    if (minX === Infinity) return null
+    if (minX === Infinity) {
+      fitCacheRef.current = { agents, toolCalls, discoveries, selectedAgentId, result: null }
+      return null
+    }
     const padding = ANIM.viewportPadding
     const boundsW = maxX - minX + padding * 2
     const boundsH = maxY - minY + padding * 2
     const centerX = (minX + maxX) / 2
     const centerY = (minY + maxY) / 2
     const scale = Math.min(dimensions.width / boundsW, dimensions.height / boundsH, 2)
-    return {
+    const result = {
       x: dimensions.width / 2 - centerX * scale,
       y: dimensions.height / 2 - centerY * scale,
       scale,
     }
+    fitCacheRef.current = { agents, toolCalls, discoveries, selectedAgentId, result }
+    return result
   }, [getDescendantIds, drawPropsRef, simTimeRef])
 
   const doZoomToFit = useCallback(() => {

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -57,14 +57,11 @@ export function useVSCodeBridge(): BridgeHookResult {
     const bridge = vscodeBridge
     if (!bridge) { return }
 
-    // Listen for bridge initialization
-    const checkInterval = setInterval(() => {
-      if (bridge.isVSCode) {
-        setIsVSCode(true)
-        setUseMockData(false)
-        clearInterval(checkInterval)
-      }
-    }, 100)
+    // Listen for bridge initialization (event-driven, no polling)
+    const unsubInit = bridge.onInit(() => {
+      setIsVSCode(true)
+      setUseMockData(false)
+    })
 
     // Listen for events — buffer by session, deliver to pending if session matches.
     // selectedSessionIdRef is updated synchronously (not via React state) so it's
@@ -188,7 +185,7 @@ export function useVSCodeBridge(): BridgeHookResult {
     })
 
     return () => {
-      clearInterval(checkInterval)
+      unsubInit()
       unsubEvent()
       unsubStatus()
       unsubConfig()

--- a/web/lib/agent-types.ts
+++ b/web/lib/agent-types.ts
@@ -251,7 +251,7 @@ export const TETHER = {
   alpha: 0.7,
   strokeAlpha: '80',
   lineWidth: 1,
-  dash: [6, 4] as readonly number[],
+  dash: [6, 4] as number[],
   dotRadius: 3,
   curveOffset: 20,
 } as const

--- a/web/lib/vscode-bridge.ts
+++ b/web/lib/vscode-bridge.ts
@@ -9,6 +9,7 @@
 export type { AgentEvent, SessionInfo, ConnectionStatus } from './bridge-types'
 import type { AgentEvent, SessionInfo, ConnectionStatus } from './bridge-types'
 
+type InitCallback = () => void
 type EventCallback = (event: AgentEvent) => void
 type StatusCallback = (status: ConnectionStatus, source: string) => void
 type ConfigCallback = (config: { mode: string; autoPlay: boolean; showMockData: boolean }) => void
@@ -19,6 +20,7 @@ class VSCodeBridge {
   private _status: ConnectionStatus = 'disconnected'
   private _source = ''
 
+  private initListeners: InitCallback[] = []
   private eventListeners: EventCallback[] = []
   private statusListeners: StatusCallback[] = []
   private configListeners: ConfigCallback[] = []
@@ -38,6 +40,8 @@ class VSCodeBridge {
       case '__vscode-bridge-init':
         this._isVSCode = true
         this.postToExtension({ type: 'ready' })
+        for (const cb of this.initListeners) cb()
+        this.initListeners = [] // one-shot: no need to keep listeners after init
         break
 
       case 'agent-event':
@@ -114,6 +118,15 @@ class VSCodeBridge {
     }
   }
 
+  /** Subscribe to bridge init. If already initialized, fires synchronously. */
+  onInit(callback: InitCallback): () => void {
+    if (this._isVSCode) {
+      callback()
+      return () => {} // already fired, nothing to unsubscribe
+    }
+    return this.subscribe(this.initListeners, callback)
+  }
+
   onEvent(callback: EventCallback): () => void {
     return this.subscribe(this.eventListeners, callback)
   }
@@ -149,12 +162,15 @@ class VSCodeBridge {
     this.postToExtension = (msg: Record<string, unknown>) => {
       postMessage(msg)
     }
+    for (const cb of this.initListeners) cb()
+    this.initListeners = []
   }
 
   dispose(): void {
     if (typeof window !== 'undefined') {
       window.removeEventListener('message', this.handleMessage)
     }
+    this.initListeners = []
     this.eventListeners = []
     this.statusListeners = []
     this.configListeners = []


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where active sessions stop rendering new events in the visualizer (bubbles freeze while chat panel keeps updating), caused by the canvas animation loop being torn down and recreated on every state change.

**Canvas render fix:**
- **Stable rAF loop** — The `requestAnimationFrame` loop now starts once and uses a `drawRef` pattern instead of being a `useEffect` dependency. Previously, every state change (new events, tool calls, particles) would teardown and recreate the loop, causing race conditions where frames were lost and rendering stopped entirely.
- **Edge lookup caching** — `activeEdgeIds` and `edgeMap` are cached across frames when inputs haven't changed, avoiding O(n) rebuilds every ~16ms.
- **Fit transform caching** — `computeFitTransform` results are cached by reference equality, reducing per-frame work in the camera system.
- **Rate-limited error logging** — Draw loop errors are logged at most once every 5s instead of flooding the console.

**Memory leak fixes:**
- **HookServer** — Consolidated `sessionStartTimes` and `agentNames` into a per-session `sessionState` Map that is cleaned up on SessionEnd/Stop, preventing unbounded growth across sessions.
- **TranscriptParser** — Added `clearSessionState()` to clean up `inlineSubagentState` and `subagentChildNames` Maps when sessions are disposed.

**Minor improvements:**
- **Bridge init** — Replaced polling `setInterval` with event-driven `onInit` callback for VS Code bridge initialization.
- **Type fix** — Fixed `setLineDash` type mismatch (`readonly number[]` → `number[]`).

## How to test

**Canvas rendering (main fix):**
1. Start a Claude Code session with Agent Flow open
2. Run a long task with many tool calls (e.g. multi-file refactor)
3. Verify bubbles continue appearing for the duration of the session — previously they would freeze after some time

**Memory leaks:**
1. Run multiple consecutive sessions without reloading VS Code
2. Monitor extension host memory — should stay stable instead of growing with each session

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)