### PR TITLE
Fix subdirectory session detection and cross-session event bleeding

### DIFF
--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -101,22 +101,21 @@ export function AgentVisualizer() {
         })
       }
 
-      // Restore or cold-start the incoming session
+      // Restore or cold-start the incoming session, then flush events.
+      // Flushing happens HERE (after state swap) to prevent the animation
+      // frame from processing events in the wrong simulation context.
       const cached = sessionCacheRef.current.get(bridge.selectedSessionId)
       if (cached) {
-        // Restore cached state + flush only events that arrived while away
         restoreSnapshot(cached.snapshot)
-        bridge.selectSession(bridge.selectedSessionId, cached.eventCount)
+        bridge.flushSessionEvents(bridge.selectedSessionId, cached.eventCount)
       } else {
-        // New session — restart and flush any events that arrived before
-        // session-started (e.g. first user message buffered in sessionEventsRef).
         restart()
-        bridge.selectSession(bridge.selectedSessionId)
+        bridge.flushSessionEvents(bridge.selectedSessionId)
       }
 
       prevSelectedRef.current = bridge.selectedSessionId
     }
-  }, [bridge.selectedSessionId, restart, bridge.selectSession, saveSnapshot, restoreSnapshot, bridge.getSessionEventCount])
+  }, [bridge.selectedSessionId, restart, bridge.flushSessionEvents, saveSnapshot, restoreSnapshot, bridge.getSessionEventCount])
 
   // Timeline events
   const timelineEvents = useMemo((): TimelineEvent[] => {

--- a/web/hooks/simulation/handle-agent-events.ts
+++ b/web/hooks/simulation/handle-agent-events.ts
@@ -20,6 +20,19 @@ export function handleAgentSpawn(
   const task = typeof payload.task === 'string' ? payload.task : undefined
   const model = typeof payload.model === 'string' ? payload.model : undefined
 
+  // If the agent already exists (e.g. session resuming after inactivity),
+  // reactivate it instead of replacing — preserves accumulated stats.
+  const existing = state.agents.get(name)
+  if (existing) {
+    state.agents.set(name, {
+      ...existing,
+      state: 'idle',
+      ...(task ? { task } : {}),
+      ...(model ? { tokensMax: ctx.getContextWindowSize(model) } : {}),
+    })
+    return
+  }
+
   let x = 0, y = 0
   if (parentId) {
     const parent = state.agents.get(parentId)

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -19,8 +19,10 @@ interface BridgeHookResult {
   sessions: SessionInfo[]
   /** Currently selected session ID */
   selectedSessionId: string | null
-  /** Select a session to view. Optional fromIndex to skip already-processed events. */
-  selectSession: (sessionId: string | null, fromIndex?: number) => void
+  /** Select a session to view (does not flush events — call flushSessionEvents after state swap). */
+  selectSession: (sessionId: string | null) => void
+  /** Flush buffered events for a session into pending. Call from useLayoutEffect after state swap. */
+  flushSessionEvents: (sessionId: string, fromIndex?: number) => void
   /** Get the current event count for a session (for save/restore) */
   getSessionEventCount: (sessionId: string) => number
   /** Ref to the currently selected session ID — updated synchronously, not via React state */
@@ -51,6 +53,9 @@ export function useVSCodeBridge(): BridgeHookResult {
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null)
   const selectedSessionIdRef = useRef<string | null>(null)
   const sessionEventsRef = useRef<Map<string, SimulationEvent[]>>(new Map())
+  /** True while a session switch is pending (between auto-select and useLayoutEffect).
+   *  Prevents the animation frame from processing events in the wrong simulation context. */
+  const sessionSwitchPendingRef = useRef(false)
   const [sessionsWithActivity, setSessionsWithActivity] = useState<Set<string>>(new Set())
 
   useEffect(() => {
@@ -81,9 +86,11 @@ export function useVSCodeBridge(): BridgeHookResult {
         sessionEventsRef.current.set(event.sessionId, buf)
       }
 
-      // Deliver to pending if session matches (ref is always current)
+      // Deliver to pending if session matches (ref is always current).
+      // Skip if a session switch is pending — useLayoutEffect will flush
+      // from the session buffer once the simulation state is swapped.
       const selected = selectedSessionIdRef.current
-      if (selected && event.sessionId === selected) {
+      if (selected && event.sessionId === selected && !sessionSwitchPendingRef.current) {
         pendingEventsRef.current.push(simEvent)
         setEventVersion(v => v + 1)
       } else if (event.sessionId && event.sessionId !== selected) {
@@ -137,7 +144,8 @@ export function useVSCodeBridge(): BridgeHookResult {
       if (type === 'list') {
         const sessionList = data as SessionInfo[]
         setSessions(sessionList)
-        // Auto-select: prefer active sessions, then most recently active
+        // Auto-select: prefer active sessions, then most recently active.
+        // Only set selection — useLayoutEffect handles flushing events.
         if (!selectedSessionIdRef.current && sessionList.length > 0) {
           const sorted = [...sessionList].sort((a, b) => {
             const aActive = a.status === 'active' ? 1 : 0
@@ -146,15 +154,10 @@ export function useVSCodeBridge(): BridgeHookResult {
             return b.lastActivityTime - a.lastActivityTime
           })
           const autoId = sorted[0].id
+          sessionSwitchPendingRef.current = true
+          pendingEventsRef.current.length = 0
           selectedSessionIdRef.current = autoId
           setSelectedSessionId(autoId)
-          // Flush any events already buffered for this session
-          const buffered = sessionEventsRef.current.get(autoId)
-          if (buffered && buffered.length > 0) {
-            pendingEventsRef.current.length = 0
-            pendingEventsRef.current.push(...buffered)
-            setEventVersion(v => v + 1)
-          }
         }
       } else if (type === 'started') {
         const session = data as SessionInfo
@@ -168,7 +171,11 @@ export function useVSCodeBridge(): BridgeHookResult {
           }
           return [...prev, session]
         })
-        // Auto-select newly started session
+        // Auto-select newly started session.
+        // Set switch-pending flag to prevent the animation frame from processing
+        // events in the wrong simulation state before useLayoutEffect swaps it.
+        sessionSwitchPendingRef.current = true
+        pendingEventsRef.current.length = 0
         selectedSessionIdRef.current = session.id
         setSelectedSessionId(session.id)
       } else if (type === 'updated') {
@@ -199,17 +206,15 @@ export function useVSCodeBridge(): BridgeHookResult {
     pendingEventsRef.current.length = 0
   }, [])
 
-  const selectSession = useCallback((sessionId: string | null, fromIndex = 0) => {
+  /** Switch session selection. Does NOT flush events — call flushSessionEvents
+   *  from useLayoutEffect after the simulation state has been saved/swapped. */
+  const selectSession = useCallback((sessionId: string | null) => {
+    // Block event delivery to pending until the simulation state is swapped
+    sessionSwitchPendingRef.current = true
+    pendingEventsRef.current.length = 0
     selectedSessionIdRef.current = sessionId
     setSelectedSessionId(sessionId)
     if (sessionId) {
-      // Flush buffered events for the new session into pending
-      // Clear in-place then push to preserve array identity for stale closures
-      const buffered = sessionEventsRef.current.get(sessionId) || []
-      pendingEventsRef.current.length = 0
-      pendingEventsRef.current.push(...buffered.slice(fromIndex))
-      setEventVersion(v => v + 1)
-      // Clear activity indicator for selected session
       setSessionsWithActivity(prev => {
         if (!prev.has(sessionId)) return prev
         const next = new Set(prev)
@@ -217,6 +222,16 @@ export function useVSCodeBridge(): BridgeHookResult {
         return next
       })
     }
+  }, [])
+
+  /** Flush buffered events for the selected session into pending.
+   *  Must be called from useLayoutEffect AFTER simulation state is saved/swapped. */
+  const flushSessionEvents = useCallback((sessionId: string, fromIndex = 0) => {
+    sessionSwitchPendingRef.current = false
+    const buffered = sessionEventsRef.current.get(sessionId) || []
+    pendingEventsRef.current.length = 0
+    pendingEventsRef.current.push(...buffered.slice(fromIndex))
+    setEventVersion(v => v + 1)
   }, [])
 
   const getSessionEventCount = useCallback((sessionId: string): number => {
@@ -254,6 +269,7 @@ export function useVSCodeBridge(): BridgeHookResult {
     selectedSessionId,
     selectedSessionIdRef,
     selectSession,
+    flushSessionEvents,
     getSessionEventCount,
     sessionsWithActivity,
     removeSession,


### PR DESCRIPTION
## What does this PR do?

- **Subdirectory session detection**: Session watcher now scans all project directories whose JSONL files contain a `cwd` under the workspace, so CLI sessions running from subdirectories are detected. Reads the authoritative `cwd` field from JSONL rather than trying to reverse the lossy path encoding.

- **Cross-session event bleeding**: Fixes event bleeding across session tabs by splitting `selectSession` into selection-only and flush-only operations. The animation frame was processing the new session's events in the old session's simulation state before `useLayoutEffect` could save/swap it.

- **Agent stats preservation**: Preserves agent stats on session resume instead of resetting them.

## How to test

1. Open a workspace in VS Code with Agent Flow enabled
2. Start a Claude Code session from a subdirectory — verify it appears in the panel
3. Open multiple sessions, switch between tabs — verify events don't bleed across sessions
4. Resume an existing session — verify agent stats are preserved from the previous run

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)