### PR TITLE
Fix Windows drive letter colon in path encoding

### DIFF
--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -124,10 +124,10 @@ export class SessionWatcher implements vscode.Disposable {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
     if (workspaceFolder) {
       // Claude Code encodes project paths: /Users/simon/project → -Users-simon-project
-      // Resolve symlinks first, then replace both / and \ (Windows) with -
+      // Resolve symlinks first, then replace /, \ (Windows), and : (drive letter) with -
       let resolved = workspaceFolder
       try { resolved = fs.realpathSync(resolved) } catch { /* use original if realpathSync fails */ }
-      const encoded = resolved.replace(/[/\\]/g, '-')
+      const encoded = resolved.replace(/[/\\:]/g, '-')
 
       // Try the resolved encoding first; fall back to unresolved if the directory doesn't exist
       // (handles edge cases where Claude Code didn't resolve symlinks the same way)
@@ -135,7 +135,7 @@ export class SessionWatcher implements vscode.Disposable {
       if (fs.existsSync(resolvedDir)) {
         this.workspacePath = encoded
       } else {
-        const unresolvedEncoded = workspaceFolder.replace(/[/\\]/g, '-')
+        const unresolvedEncoded = workspaceFolder.replace(/[/\\:]/g, '-')
         const unresolvedDir = path.join(CLAUDE_DIR, unresolvedEncoded)
         this.workspacePath = fs.existsSync(unresolvedDir) ? unresolvedEncoded : encoded
       }


### PR DESCRIPTION
## What does this PR do?

Fixes path encoding on Windows to also replace drive letter colons (e.g. `c:\Users\username\project` → `c--Users-username-project`). The previous regex only replaced slashes, leaving the colon intact and producing invalid paths that prevented session detection.

Addresses [#4](https://github.com/patoles/agent-flow/issues/4).

## How to test

1. Open a workspace in VS Code on Windows
2. Start a Claude Code session
3. Verify the session appears in the Agent Flow panel

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)