### PR TITLE
feat: add OpenClaw standalone mode via ?mode=openclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,58 @@ Created by [Simon Patole](https://github.com/patoles), for [CraftMyGame](https:/
 Apache 2.0 — see [LICENSE](LICENSE) for details.
 
 The name "Agent Flow" and associated logos are trademarks of Simon Patole. See [TRADEMARK.md](TRADEMARK.md) for usage guidelines.
+
+## OpenClaw / Standalone Mode
+
+You can run Agent Flow as a standalone web app (without VS Code) and connect it to any Claude Code–compatible agent runtime, including [OpenClaw](https://openclaw.dev).
+
+### Architecture
+
+```
+Agent runtime (OpenClaw / Claude Code)
+        │  HTTP POST :7842
+        ▼
+  hook-server.mjs  ←── Receives hook events, translates to SimulationEvents
+        │  WebSocket :7850
+        ▼
+  Next.js browser  ←── Renders live graph
+```
+
+### Quick Start (OpenClaw)
+
+```bash
+# 1. Install dependencies
+cd web && npm install
+
+# 2. Start the standalone dev server (Next.js + hook server together)
+npm run dev:standalone
+
+# 3. In a separate terminal, run the OpenClaw bridge
+node scripts/openclaw-bridge.mjs
+
+# 4. Open http://localhost:3000
+```
+
+The bridge watches your active OpenClaw session JSONL and forwards events to the hook server, which streams them live to the browser.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `HOOK_SERVER_PORT` | `7842` | HTTP port for receiving hook events |
+| `HUB_SERVER_PORT` | `7850` | WebSocket port for browser clients |
+| `OPENCLAW_SESSION_DIR` | `~/.openclaw/agents/main/sessions` | Directory to watch for JSONL files |
+| `REPLAY_HISTORY` | `0` | Set to `1` to replay full session history on start |
+
+### Connecting Claude Code Directly
+
+Add to `~/.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse":  [{ "type": "command", "command": "curl -sf -X POST http://127.0.0.1:7842 -H 'Content-Type: application/json' -d @-" }],
+    "PostToolUse": [{ "type": "command", "command": "curl -sf -X POST http://127.0.0.1:7842 -H 'Content-Type: application/json' -d @-" }]
+  }
+}
+```

--- a/scripts/openclaw-bridge.mjs
+++ b/scripts/openclaw-bridge.mjs
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+/**
+ * openclaw-agent-flow-bridge.mjs
+ *
+ * Tails the active OpenClaw session JSONL and emits Claude Code-compatible
+ * hook events to the Agent Flow standalone hook server (port 7842).
+ *
+ * Events emitted:
+ *   SessionStart    — on startup (registers the session)
+ *   PreToolUse      — when an assistant toolCall is appended
+ *   PostToolUse     — when the following toolResult message is appended
+ *   Message         — assistant text, user text, and thinking indicators
+ *   SubagentStart   — when an Agent tool call is detected
+ *   SubagentStop    — when the Agent tool result returns
+ *   ModelChange     — when a model_change entry is found
+ *   Stop            — when the session file hasn't grown for IDLE_MS (optional)
+ *
+ * Usage:
+ *   node openclaw-agent-flow-bridge.mjs [session.jsonl]
+ *   HOOK_SERVER_PORT=7842 OPENCLAW_SESSION_DIR=... node openclaw-agent-flow-bridge.mjs
+ */
+
+import fs from 'fs'
+import path from 'path'
+import http from 'http'
+import os from 'os'
+import crypto from 'crypto'
+
+const HOOK_PORT = parseInt(process.env.HOOK_SERVER_PORT || '7842', 10)
+const SESSION_DIR = process.env.OPENCLAW_SESSION_DIR
+  || path.join(os.homedir(), '.openclaw', 'agents', 'main', 'sessions')
+const POLL_MS = 300          // how often to check for new lines
+const IDLE_MS = 0            // disabled (was 30000) — idle Stop causes race with agent_complete
+const SESSION_LABEL = 'OpenClaw (main)'
+
+// ── OpenClaw → Claude Code tool name mapping ─────────────────────────────
+
+const TOOL_NAME_MAP = {
+  exec: 'Bash',
+  process: 'Bash',
+  read: 'Read',
+  write: 'Write',
+  edit: 'Edit',
+  browser: 'WebFetch',
+  web_fetch: 'WebFetch',
+  web_search: 'WebSearch',
+  message: 'Reply',
+  sessions_spawn: 'Agent',
+  sessions_list: 'SessionList',
+  subagents: 'Agent',
+}
+
+function mapToolName(name) {
+  return TOOL_NAME_MAP[name] || name
+}
+
+/** Extract a human-readable summary from OpenClaw tool input */
+function summarizeToolInput(toolName, input) {
+  if (!input || typeof input !== 'object') return ''
+  switch (toolName) {
+    case 'exec':
+    case 'process':
+      return String(input.command || input.action || '').slice(0, 120)
+    case 'read':
+      return String(input.file_path || input.path || '')
+    case 'write':
+    case 'edit':
+      return String(input.file_path || input.path || '')
+    case 'browser':
+    case 'web_fetch':
+      return String(input.url || '').slice(0, 120)
+    case 'web_search':
+      return String(input.query || '').slice(0, 80)
+    case 'message':
+      return String(input.content || input.text || '').slice(0, 80)
+    case 'sessions_spawn':
+    case 'subagents':
+      return String(input.prompt || input.description || '').slice(0, 80)
+    default:
+      return JSON.stringify(input).slice(0, 80)
+  }
+}
+
+/** Strip OpenClaw system prefixes (Engram memory context, sender metadata) from user messages */
+function cleanUserMessage(text) {
+  // Find the LAST ``` block end — everything after it is the actual user message
+  // OpenClaw wraps system context in markdown code fences, the user text follows the last one
+  const parts = text.split(/```\s*\n/)
+  if (parts.length >= 3) {
+    // Take everything after the last code fence
+    const lastPart = parts[parts.length - 1].trim()
+    if (lastPart && !lastPart.startsWith('## ') && !lastPart.startsWith('Sender')) {
+      return lastPart
+    }
+  }
+  // Strategy 2: find timestamp marker
+  const tsMatch = text.match(/\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+\d{4}-\d{2}-\d{2}\s+\d{1,2}:\d{2}\s+GMT[^\]]*\]\s*([\s\S]*)/i)
+  if (tsMatch && tsMatch[1]?.trim()) {
+    return tsMatch[1].trim()
+  }
+  // Strategy 3: if it's pure system context, skip
+  if (text.startsWith('## Memory Context') || text.startsWith('Sender (untrusted')) {
+    return ''
+  }
+  // Strategy 4: no system prefix, return as-is
+  return text.trim()
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function latestSessionFile(dir) {
+  let best = null, bestMtime = 0
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith('.jsonl')) continue
+    const full = path.join(dir, f)
+    const mt = fs.statSync(full).mtimeMs
+    if (mt > bestMtime) { bestMtime = mt; best = full }
+  }
+  return best
+}
+
+function postEvent(payload) {
+  return new Promise((resolve) => {
+    const body = JSON.stringify(payload)
+    const req = http.request({
+      hostname: '127.0.0.1',
+      port: HOOK_PORT,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) }
+    }, (res) => { res.resume(); resolve(res.statusCode) })
+    req.on('error', () => resolve(null))
+    req.setTimeout(1500, () => { req.destroy(); resolve(null) })
+    req.write(body)
+    req.end()
+  })
+}
+
+// ── session state ──────────────────────────────────────────────────────────
+
+let sessionFile = process.argv[2] || latestSessionFile(SESSION_DIR)
+if (!sessionFile) { console.error('[bridge] No session file found in', SESSION_DIR); process.exit(1) }
+
+// Derive a stable session ID from the filename
+const sessionId = path.basename(sessionFile, '.jsonl')
+const cwd = os.homedir()
+
+console.log('[bridge] Watching:', sessionFile)
+console.log('[bridge] Session ID:', sessionId)
+console.log('[bridge] Hook server: http://127.0.0.1:' + HOOK_PORT)
+
+// Emit SessionStart so Agent Flow registers us
+await postEvent({ hook_event_name: 'SessionStart', session_id: sessionId, cwd, label: SESSION_LABEL })
+console.log('[bridge] SessionStart sent')
+
+// ── tail loop ──────────────────────────────────────────────────────────────
+
+// Start from end of file (live-only) by default. Set REPLAY_HISTORY=1 to replay full history.
+const REPLAY_HISTORY = process.env.REPLAY_HISTORY === '1'
+let filePos = REPLAY_HISTORY ? 0 : fs.statSync(sessionFile).size
+let lastGrowthAt = Date.now()
+let pendingToolCall = null   // { toolId, toolName, toolInput }
+let pendingSubagents = new Map()  // toolCallId → { agentType, agentId, prompt }
+let stopped = false          // true after idle Stop, reset on activity
+let sessionStartTimestamp = null // ISO timestamp of the session entry, for elapsed time calc
+
+async function poll() {
+  let stat
+  try { stat = fs.statSync(sessionFile) } catch { return }
+
+  // If file rotated (new session) handle gracefully
+  if (stat.size < filePos) { filePos = 0 }
+
+  if (stat.size === filePos) {
+    // No new data
+    if (IDLE_MS > 0 && pendingToolCall === null && Date.now() - lastGrowthAt > IDLE_MS) {
+      // Nothing for a while — no Stop spam (only once)
+      lastGrowthAt = Date.now() + 1e9
+      stopped = true
+      await postEvent({ hook_event_name: 'Stop', session_id: sessionId, cwd })
+      console.log('[bridge] Stop sent (idle)')
+    }
+    return
+  }
+
+  lastGrowthAt = Date.now()
+
+  // Resume after idle stop — re-register the session so a new agent_spawn is emitted
+  if (stopped) {
+    stopped = false
+    await postEvent({ hook_event_name: 'SessionStart', session_id: sessionId, cwd, label: SESSION_LABEL })
+    console.log('[bridge] SessionStart re-sent (resumed after idle)')
+  }
+
+  const fd = fs.openSync(sessionFile, 'r')
+  const chunk = Buffer.alloc(stat.size - filePos)
+  fs.readSync(fd, chunk, 0, chunk.length, filePos)
+  fs.closeSync(fd)
+  filePos = stat.size
+
+  const newText = chunk.toString('utf8')
+  const lines = newText.split('\n').filter(l => l.trim())
+
+  for (const line of lines) {
+    let entry
+    try { entry = JSON.parse(line) } catch { continue }
+
+    // ── session entry — capture start timestamp ──────────────────────────
+    if (entry.type === 'session') {
+      sessionStartTimestamp = entry.timestamp ? new Date(entry.timestamp).getTime() : Date.now()
+      continue
+    }
+
+    // Compute elapsed seconds from session start for proper timeline spacing
+    const entryTime = entry.timestamp ? new Date(entry.timestamp).getTime() : Date.now()
+    const elapsedSec = sessionStartTimestamp
+      ? Math.max(0, (entryTime - sessionStartTimestamp) / 1000)
+      : 0
+
+    // ── model_change ──────────────────────────────────────────────────────
+    if (entry.type === 'model_change') {
+      const modelId = entry.modelId || ''
+      if (modelId) {
+        await postEvent({ hook_event_name: 'ModelChange', session_id: sessionId, cwd, model_id: modelId, elapsed_sec: elapsedSec })
+        console.log(`[bridge] ModelChange → ${modelId} @${elapsedSec.toFixed(1)}s`)
+      }
+      continue
+    }
+
+    if (entry.type !== 'message') continue
+    const msg = entry.message || {}
+    const role = msg.role
+    const content = Array.isArray(msg.content) ? msg.content : []
+
+    // ── assistant messages ────────────────────────────────────────────────
+    if (role === 'assistant') {
+      for (const c of content) {
+        if (!c) continue
+
+        // Thinking indicator
+        if (c.type === 'thinking') {
+          const thinkingText = c.thinking || c.text || ''
+          await postEvent({
+            hook_event_name: 'Message',
+            session_id: sessionId,
+            cwd,
+            role: 'thinking',
+            content: thinkingText ? thinkingText.slice(0, 500) : '[thinking...]',
+            elapsed_sec: elapsedSec,
+          })
+          console.log(`[bridge] Message thinking @${elapsedSec.toFixed(1)}s`)
+          continue
+        }
+
+        // Assistant text
+        if (c.type === 'text' && c.text) {
+          await postEvent({
+            hook_event_name: 'Message',
+            session_id: sessionId,
+            cwd,
+            role: 'assistant',
+            content: c.text.slice(0, 1000),
+            elapsed_sec: elapsedSec,
+          })
+          console.log(`[bridge] Message assistant @${elapsedSec.toFixed(1)}s`)
+          continue
+        }
+
+        // Tool call
+        if (c.type === 'toolCall') {
+          const rawToolName = c.name || 'unknown'
+          const toolName = mapToolName(rawToolName)
+          const toolInput = c.arguments || {}
+          pendingToolCall = { toolId: c.id, toolName: rawToolName, toolInput }
+
+          // Build a clean summarized input for display
+          const summarized = summarizeToolInput(rawToolName, toolInput)
+          const cleanInput = { ...toolInput, _summary: summarized }
+
+          // Detect Agent tool calls → SubagentStart
+          if (rawToolName === 'Agent' || rawToolName === 'sessions_spawn' || rawToolName === 'subagents') {
+            const agentType = toolInput.subagent_type || 'general-purpose'
+            const agentId = c.id || crypto.randomUUID()
+            const prompt = toolInput.prompt || toolInput.description || ''
+            pendingSubagents.set(c.id, { agentType, agentId, prompt })
+            await postEvent({
+              hook_event_name: 'SubagentStart',
+              session_id: sessionId,
+              cwd,
+              agent_type: agentType,
+              agent_id: agentId,
+              prompt: prompt.slice(0, 200),
+              elapsed_sec: elapsedSec,
+            })
+            console.log(`[bridge] SubagentStart ${agentType} @${elapsedSec.toFixed(1)}s`)
+          }
+
+          const ev = {
+            hook_event_name: 'PreToolUse',
+            session_id: sessionId,
+            cwd,
+            tool_name: toolName,
+            tool_input: cleanInput,
+            elapsed_sec: elapsedSec,
+          }
+          const status = await postEvent(ev)
+          console.log(`[bridge] PreToolUse ${toolName} → ${status}`)
+        }
+      }
+    }
+
+    // ── user messages ─────────────────────────────────────────────────────
+    if (role === 'user') {
+      for (const c of content) {
+        if (!c) continue
+        if (c.type === 'text' && c.text) {
+          const cleaned = cleanUserMessage(c.text)
+          if (!cleaned) continue  // skip empty/system-only messages
+          await postEvent({
+            hook_event_name: 'Message',
+            session_id: sessionId,
+            cwd,
+            role: 'user',
+            content: cleaned.slice(0, 500),
+            elapsed_sec: elapsedSec,
+          })
+          console.log(`[bridge] Message user @${elapsedSec.toFixed(1)}s: "${cleaned.slice(0, 60)}"`)
+        }
+      }
+    }
+
+    // ── toolResult (role = "toolResult") ──────────────────────────────────
+    if (role === 'toolResult') {
+      const textContent = content.find(c => c && c.type === 'text')
+      const rawResult = textContent ? textContent.text : ''
+      const rawToolName = pendingToolCall?.toolName || 'unknown'
+      const toolName = mapToolName(rawToolName)
+      const toolInput = pendingToolCall?.toolInput || {}
+      const toolId = pendingToolCall?.toolId
+
+      // Check if this is a returning subagent
+      if (toolId && pendingSubagents.has(toolId)) {
+        const sub = pendingSubagents.get(toolId)
+        pendingSubagents.delete(toolId)
+        await postEvent({
+          hook_event_name: 'SubagentStop',
+          session_id: sessionId,
+          cwd,
+          agent_type: sub.agentType,
+          agent_id: sub.agentId,
+          elapsed_sec: elapsedSec,
+        })
+        console.log(`[bridge] SubagentStop ${sub.agentType} @${elapsedSec.toFixed(1)}s`)
+      }
+
+      const ev = {
+        hook_event_name: 'PostToolUse',
+        session_id: sessionId,
+        cwd,
+        tool_name: toolName,
+        tool_input: toolInput,
+        tool_response: rawResult.slice(0, 2000),  // cap size
+        elapsed_sec: elapsedSec,
+      }
+      const status = await postEvent(ev)
+      console.log(`[bridge] PostToolUse ${toolName} → ${status}`)
+      pendingToolCall = null
+    }
+  }
+}
+
+// ── watch for new session files too ───────────────────────────────────────
+function checkSessionRotate() {
+  const latest = latestSessionFile(SESSION_DIR)
+  if (latest && latest !== sessionFile) {
+    console.log('[bridge] New session file detected:', latest)
+    sessionFile = latest
+    filePos = 0
+    pendingToolCall = null
+    pendingSubagents.clear()
+    postEvent({ hook_event_name: 'SessionStart', session_id: path.basename(latest,'.jsonl'), cwd, label: SESSION_LABEL })
+      .then(() => console.log('[bridge] SessionStart sent for new session'))
+  }
+}
+
+setInterval(poll, POLL_MS)
+// Only auto-rotate if no explicit session file was given
+if (!process.argv[2]) setInterval(checkSessionRotate, 5000)
+
+process.on('SIGINT', async () => {
+  await postEvent({ hook_event_name: 'Stop', session_id: sessionId, cwd })
+  console.log('\n[bridge] Stop sent, exiting')
+  process.exit(0)
+})
+
+console.log('[bridge] Running — waiting for tool calls...')

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -28,9 +28,13 @@ import { useAudioEffects } from "@/hooks/use-audio-effects"
 
 export function AgentVisualizer() {
   const vscodeBridge = useVSCodeBridge()
-  const hubBridge = useEventHub()
-  // Prefer event hub when connected; fall back to VS Code bridge otherwise
-  const bridge = hubBridge.connectionStatus === 'connected' ? hubBridge : vscodeBridge
+  // Standalone modes: ?mode=openclaw or ?mode=claude-code connects to an event hub
+  const mode = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('mode')
+    : null
+  const hubEnabled = mode === 'openclaw' || mode === 'claude-code'
+  const hubBridge = useEventHub({ enabled: hubEnabled })
+  const bridge = hubEnabled ? hubBridge : vscodeBridge
 
   const {
     agents,

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo, useEffect, useLayoutEffect, useRef } from "react"
 import { useAgentSimulation } from "@/hooks/use-agent-simulation"
 import { useVSCodeBridge } from "@/hooks/use-vscode-bridge"
+import { useEventHub } from "@/hooks/use-event-hub"
 import { useSelectionState } from "@/hooks/use-selection-state"
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
 import { AgentCanvas } from "./canvas"
@@ -26,7 +27,10 @@ import { TopBar } from "./top-bar"
 import { useAudioEffects } from "@/hooks/use-audio-effects"
 
 export function AgentVisualizer() {
-  const bridge = useVSCodeBridge()
+  const vscodeBridge = useVSCodeBridge()
+  const hubBridge = useEventHub()
+  // Prefer event hub when connected; fall back to VS Code bridge otherwise
+  const bridge = hubBridge.connectionStatus === 'connected' ? hubBridge : vscodeBridge
 
   const {
     agents,
@@ -79,10 +83,10 @@ export function AgentVisualizer() {
   const [isReviewing, setIsReviewing] = useState(false)
   const { isMuted, seekingRef, handleToggleMute } = useAudioEffects(agents, toolCalls, isReviewing)
 
-  // Auto-play on mount
+  // Auto-play on mount — play immediately to avoid missing events
+  // that arrive before the delayed timer fires
   useEffect(() => {
-    const timer = setTimeout(() => play(), TIMING.autoPlayDelayMs)
-    return () => clearTimeout(timer)
+    play()
   }, [play])
 
   // Per-session state cache: save/restore simulation state on tab switch
@@ -93,12 +97,22 @@ export function AgentVisualizer() {
   const prevSelectedRef = useRef<string | null>(null)
   useLayoutEffect(() => {
     if (bridge.selectedSessionId && bridge.selectedSessionId !== prevSelectedRef.current) {
-      // Save outgoing session state (if any)
-      if (prevSelectedRef.current !== null) {
-        sessionCacheRef.current.set(prevSelectedRef.current, {
+      const isInitialSelection = prevSelectedRef.current === null
+
+      // Save outgoing session state (if switching away from an existing session)
+      if (!isInitialSelection) {
+        sessionCacheRef.current.set(prevSelectedRef.current!, {
           snapshot: saveSnapshot(),
-          eventCount: bridge.getSessionEventCount(prevSelectedRef.current),
+          eventCount: bridge.getSessionEventCount(prevSelectedRef.current!),
         })
+      }
+
+      prevSelectedRef.current = bridge.selectedSessionId
+
+      // For initial selection, DON'T restart — events are already flowing
+      // from the hub's auto-replay. Restarting would clear them.
+      if (isInitialSelection) {
+        return
       }
 
       // Restore or cold-start the incoming session, then flush events.
@@ -112,8 +126,6 @@ export function AgentVisualizer() {
         restart()
         bridge.flushSessionEvents(bridge.selectedSessionId)
       }
-
-      prevSelectedRef.current = bridge.selectedSessionId
     }
   }, [bridge.selectedSessionId, restart, bridge.flushSessionEvents, saveSnapshot, restoreSnapshot, bridge.getSessionEventCount])
 

--- a/web/hook-server.mjs
+++ b/web/hook-server.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+/**
+ * hook-server.mjs — Agent Flow standalone event hub
+ *
+ * Two-port architecture:
+ *   HTTP  :7842  — Receives Claude Code–compatible hook events (POST /)
+ *   WebSocket :7850/ws — Streams SimulationEvents to the Next.js browser client
+ *
+ * External tools (Claude Code hooks, the OpenClaw bridge, any MCP client) POST
+ * JSON to :7842.  The server converts those hook payloads into SimulationEvents
+ * and broadcasts them to every connected browser tab via WebSocket.
+ *
+ * Claude Code hook event → SimulationEvent mapping:
+ *   SessionStart    → agent_spawn   (isMain: true)
+ *   Stop            → agent_complete
+ *   PreToolUse      → tool_call_start
+ *   PostToolUse     → tool_call_end
+ *   Message         → message
+ *   SubagentStart   → subagent_dispatch + agent_spawn (child)
+ *   SubagentStop    → subagent_return  + agent_complete (child)
+ *   ModelChange     → model_detected
+ */
+
+import http from 'http'
+import { WebSocketServer } from 'ws'
+
+const HOOK_PORT = parseInt(process.env.HOOK_SERVER_PORT || '7842', 10)
+const HUB_PORT  = parseInt(process.env.HUB_SERVER_PORT  || '7850', 10)
+const MAX_EVENTS_PER_SESSION = 2000
+
+// ── In-memory state ────────────────────────────────────────────────────────
+
+/**
+ * @typedef {{ id: string, label: string, status: 'active'|'completed', startTime: number, lastActivityTime: number }} HubSession
+ * @typedef {{ time: number, type: string, payload: Record<string,unknown>, sessionId?: string }} SimEvent
+ */
+
+/** @type {Map<string, HubSession>} */
+const sessions = new Map()
+
+/** @type {Map<string, SimEvent[]>} */
+const sessionEvents = new Map()
+
+/** @type {Map<string, number>} session wall-clock start time (ms) */
+const sessionWallStart = new Map()
+
+/** @type {Map<string, Map<string, string>>} sessionId → (toolCallId → agentName) */
+const pendingSubagents = new Map()
+
+/** @type {Set<import('ws').WebSocket>} */
+const wsClients = new Set()
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function now() { return Date.now() }
+
+function simTime(sessionId) {
+  const start = sessionWallStart.get(sessionId) ?? now()
+  return (now() - start) / 1000
+}
+
+function pushEvent(sessionId, event) {
+  let buf = sessionEvents.get(sessionId)
+  if (!buf) { buf = []; sessionEvents.set(sessionId, buf) }
+  if (buf.length >= MAX_EVENTS_PER_SESSION) buf.shift()
+  buf.push(event)
+
+  // Update session activity timestamp
+  const sess = sessions.get(sessionId)
+  if (sess) sess.lastActivityTime = now()
+
+  broadcast({ type: 'event', event })
+}
+
+function broadcast(msg) {
+  const str = JSON.stringify(msg)
+  for (const ws of wsClients) {
+    if (ws.readyState === 1 /* OPEN */) {
+      try { ws.send(str) } catch { /* ignore */ }
+    }
+  }
+}
+
+// ── Tool summarization ─────────────────────────────────────────────────────
+
+function summarizeInput(toolName, input) {
+  if (!input || typeof input !== 'object') return ''
+  const s = String
+  switch (toolName.toLowerCase()) {
+    case 'bash':
+    case 'exec':
+      return s(input.command || input.cmd || '').slice(0, 120)
+    case 'read':
+      return s(input.file_path || input.path || '')
+    case 'write':
+    case 'edit':
+      return s(input.file_path || input.path || '')
+    case 'webfetch':
+    case 'web_fetch':
+      return s(input.url || '').slice(0, 120)
+    case 'websearch':
+    case 'web_search':
+      return s(input.query || '').slice(0, 80)
+    case 'grep':
+    case 'globsearch':
+      return s(input.pattern || input.glob || '').slice(0, 80)
+    case 'todoread':
+    case 'todowrite':
+      return s(input.todos?.[0]?.content || '').slice(0, 60)
+    case 'agent':
+    case 'sessions_spawn':
+    case 'subagents':
+      return s(input.prompt || input.task || input.description || '').slice(0, 80)
+    case 'memory_search':
+    case 'memory_store':
+      return s(input.query || input.content || '').slice(0, 80)
+    default: {
+      // Generic: probe common summary keys in priority order
+      const keys = ['command', 'query', 'url', 'path', 'file_path', 'content', 'message', 'text', 'description', 'task']
+      for (const k of keys) {
+        const v = input[k]
+        if (v && typeof v === 'string') return v.slice(0, 80)
+      }
+      return JSON.stringify(input).slice(0, 80)
+    }
+  }
+}
+
+function summarizeResult(toolName, result) {
+  if (!result || typeof result !== 'string') return ''
+  // First non-empty line, trimmed
+  const line = result.split('\n').find(l => l.trim())
+  return (line || result).slice(0, 120)
+}
+
+// ── Hook event → SimulationEvent translation ───────────────────────────────
+
+function handleHookEvent(body) {
+  const evt  = body.hook_event_name || body.event || ''
+  const sid  = body.session_id || 'default'
+  const cwd  = body.cwd || process.cwd()
+  const t    = typeof body.elapsed_sec === 'number'
+                 ? body.elapsed_sec
+                 : simTime(sid)
+
+  if (!sessions.has(sid)) {
+    // Auto-create session on first event
+    const label = body.label || cwd.split('/').pop() || sid.slice(0, 8)
+    sessions.set(sid, { id: sid, label, status: 'active', startTime: now(), lastActivityTime: now() })
+    sessionWallStart.set(sid, now())
+    pendingSubagents.set(sid, new Map())
+    broadcast({ type: 'session-started', session: sessions.get(sid) })
+  }
+
+  switch (evt) {
+    case 'SessionStart': {
+      const label = body.label || cwd.split('/').pop() || sid.slice(0, 8)
+      // Update or create
+      const existing = sessions.get(sid)
+      if (existing) {
+        existing.label = label
+        existing.status = 'active'
+        broadcast({ type: 'session-updated', sessionId: sid, label })
+      } else {
+        sessionWallStart.set(sid, now())
+      }
+      pendingSubagents.set(sid, new Map())
+      pushEvent(sid, { time: t, type: 'agent_spawn', sessionId: sid, payload: {
+        agent: sid, cwd, isMain: true, task: label,
+      }})
+      break
+    }
+
+    case 'Stop': {
+      const sess = sessions.get(sid)
+      if (sess) sess.status = 'completed'
+      broadcast({ type: 'session-ended', sessionId: sid })
+      pushEvent(sid, { time: t, type: 'agent_complete', sessionId: sid, payload: { agent: sid } })
+      break
+    }
+
+    case 'PreToolUse': {
+      const rawTool = body.tool_name || 'unknown'
+      const input   = body.tool_input || {}
+      const args    = summarizeInput(rawTool, input)
+      pushEvent(sid, { time: t, type: 'tool_call_start', sessionId: sid, payload: {
+        agent: sid, tool: rawTool, args, inputData: input,
+      }})
+      break
+    }
+
+    case 'PostToolUse': {
+      const rawTool = body.tool_name || 'unknown'
+      const result  = typeof body.tool_response === 'string' ? body.tool_response : JSON.stringify(body.tool_response || '')
+      const summary = summarizeResult(rawTool, result)
+      const isError = /error|failed|exception/i.test(result.slice(0, 200))
+      pushEvent(sid, { time: t, type: 'tool_call_end', sessionId: sid, payload: {
+        agent: sid, tool: rawTool, result: summary, error: isError,
+      }})
+      break
+    }
+
+    case 'Message': {
+      const role    = body.role || 'assistant'
+      const content = body.content || ''
+      pushEvent(sid, { time: t, type: 'message', sessionId: sid, payload: {
+        agent: sid, role, content,
+      }})
+      break
+    }
+
+    case 'SubagentStart': {
+      const agentType = body.agent_type || 'subagent'
+      const agentId   = body.agent_id   || `sub-${t.toFixed(0)}`
+      const prompt    = body.prompt     || ''
+      const sub = pendingSubagents.get(sid)
+      if (sub) sub.set(agentId, agentId)
+      // Dispatch event from parent
+      pushEvent(sid, { time: t, type: 'subagent_dispatch', sessionId: sid, payload: {
+        agent: sid, childAgent: agentId, task: prompt,
+      }})
+      // Spawn the child agent node
+      pushEvent(sid, { time: t, type: 'agent_spawn', sessionId: sid, payload: {
+        agent: agentId, cwd, isMain: false, parentAgent: sid, task: prompt,
+      }})
+      break
+    }
+
+    case 'SubagentStop': {
+      const agentId = body.agent_id || ''
+      const sub = pendingSubagents.get(sid)
+      if (sub) sub.delete(agentId)
+      pushEvent(sid, { time: t, type: 'agent_complete', sessionId: sid, payload: {
+        agent: agentId,
+      }})
+      pushEvent(sid, { time: t, type: 'subagent_return', sessionId: sid, payload: {
+        agent: sid, childAgent: agentId,
+      }})
+      break
+    }
+
+    case 'ModelChange': {
+      pushEvent(sid, { time: t, type: 'model_detected', sessionId: sid, payload: {
+        agent: sid, model: body.model_id || '',
+      }})
+      break
+    }
+
+    default:
+      // Unknown event — silently ignore
+      break
+  }
+}
+
+// ── HTTP hook receiver (port 7842) ─────────────────────────────────────────
+
+const hookServer = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ status: 'ok', sessions: sessions.size }))
+    return
+  }
+
+  if (req.method !== 'POST') {
+    res.writeHead(405); res.end('Method Not Allowed'); return
+  }
+
+  let raw = ''
+  req.on('data', d => { raw += d })
+  req.on('end', () => {
+    try {
+      const body = JSON.parse(raw)
+      handleHookEvent(body)
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok: true }))
+    } catch (err) {
+      console.error('[hook-server] parse error:', err.message)
+      res.writeHead(400); res.end('Bad Request')
+    }
+  })
+})
+
+hookServer.listen(HOOK_PORT, '127.0.0.1', () => {
+  console.log(`[hook-server] HTTP hook receiver listening on http://127.0.0.1:${HOOK_PORT}`)
+})
+
+// ── WebSocket hub (port 7850) ───────────────────────────────────────────────
+
+const hubServer = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' })
+  res.end('Agent Flow Event Hub\n')
+})
+
+const wss = new WebSocketServer({ server: hubServer, path: '/ws' })
+
+wss.on('connection', (ws) => {
+  wsClients.add(ws)
+  console.log(`[hub] Client connected (total: ${wsClients.size})`)
+
+  // Send the current session list immediately
+  const sessionList = [...sessions.values()]
+  const mostRecent  = sessionList.sort((a, b) => b.lastActivityTime - a.lastActivityTime)[0]
+  ws.send(JSON.stringify({
+    type: 'session-list',
+    sessions: sessionList,
+    selectedSessionId: mostRecent?.id,
+  }))
+
+  // Replay buffered events for the most recent session
+  if (mostRecent) {
+    const events = sessionEvents.get(mostRecent.id) || []
+    if (events.length > 0) {
+      ws.send(JSON.stringify({ type: 'event-batch', events }))
+    }
+  }
+
+  ws.on('message', (data) => {
+    try {
+      const msg = JSON.parse(data.toString())
+      if (msg.type === 'select-session' && msg.sessionId) {
+        const events = sessionEvents.get(msg.sessionId) || []
+        ws.send(JSON.stringify({ type: 'event-batch', events }))
+      }
+    } catch { /* ignore */ }
+  })
+
+  ws.on('close', () => {
+    wsClients.delete(ws)
+    console.log(`[hub] Client disconnected (total: ${wsClients.size})`)
+  })
+
+  ws.on('error', () => wsClients.delete(ws))
+})
+
+hubServer.listen(HUB_PORT, () => {
+  console.log(`[hub] WebSocket hub listening on ws://localhost:${HUB_PORT}/ws`)
+})
+
+console.log('[agent-flow] Hook server ready. Waiting for events...')
+console.log('[agent-flow] Run the bridge with: node scripts/openclaw-bridge.mjs')

--- a/web/hooks/simulation/handle-message-events.ts
+++ b/web/hooks/simulation/handle-message-events.ts
@@ -19,11 +19,16 @@ export function handleMessage(
     'assistant'
 
   // Rename main agent to the first user message (more recognizable than "orchestrator")
+  // Only rename if the name is still a generic default — skip if it's already meaningful
+  // (e.g. "OpenClaw" from event hub, or any non-default name)
   if (role === 'user') {
     const msgAgentForName = state.agents.get(agentName)
-    if (msgAgentForName && msgAgentForName.isMain && msgAgentForName.name === agentName) {
+    if (msgAgentForName && msgAgentForName.isMain && msgAgentForName.name === 'Orchestrator') {
       const shortName = content.slice(0, LABEL_LEN_NAME).replace(/\n/g, ' ').trim()
       state.agents.set(agentName, { ...msgAgentForName, name: shortName || agentName, task: content.slice(0, LABEL_LEN_TASK) })
+    } else if (msgAgentForName && msgAgentForName.isMain && !msgAgentForName.task) {
+      // Still set the task (shown as subtitle) even if we keep the name
+      state.agents.set(agentName, { ...msgAgentForName, task: content.slice(0, LABEL_LEN_TASK) })
     }
   }
 

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -166,6 +166,16 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     const deltaTime = Math.min((timestamp - lastTimeRef.current) / 1000, ANIM_SPEED.maxDeltaTime)
     lastTimeRef.current = timestamp
 
+    // Snapshot and consume external events OUTSIDE setState so that
+    // React StrictMode's double-invocation of the updater doesn't
+    // see an empty array on the second call (the first call would
+    // have cleared it via onExternalEventsConsumed).
+    let externalSnapshot: SimulationEvent[] | null = null
+    if (externalEvents && externalEvents.length > 0) {
+      externalSnapshot = externalEvents.slice()
+      onExternalEventsConsumed?.()
+    }
+
     setState(prev => {
       if (!prev.isPlaying) return prev
 
@@ -198,13 +208,9 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
         }
       }
 
-      // Process NEW external events (from VS Code bridge)
-      // Copy and clear immediately to prevent stale closures from
-      // reprocessing the same events across multiple animation frames
-      if (externalEvents && externalEvents.length > 0) {
-        const eventsToProcess = externalEvents.slice()
-        onExternalEventsConsumed?.()
-        for (const event of eventsToProcess) {
+      // Process NEW external events (from VS Code bridge / event hub)
+      if (externalSnapshot) {
+        for (const event of externalSnapshot) {
           // Filter by session if specified — use ref so we always read the
           // latest value even if the animate closure hasn't been recreated yet.
           // The ref is also updated synchronously via onSessionFilterChange callback

--- a/web/hooks/use-event-hub.ts
+++ b/web/hooks/use-event-hub.ts
@@ -1,15 +1,24 @@
 'use client'
 
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { eventHubClient, type HubSessionInfo } from '@/lib/event-hub-client'
+import { createEventHubClient, type HubSessionInfo } from '@/lib/event-hub-client'
 import type { SimulationEvent } from '@/lib/agent-types'
 import type { SessionInfo, ConnectionStatus } from '@/lib/vscode-bridge'
 
+interface UseEventHubOptions {
+  /** Set to true to activate the hub connection (default: false) */
+  enabled?: boolean
+  /** Custom WebSocket URL (default: ws://localhost:7850/ws) */
+  url?: string
+}
+
 /**
  * React hook that connects to the agent-viz event hub via WebSocket.
+ * Only connects when enabled=true (triggered by ?hub query param).
  * Returns the same shape as useVSCodeBridge so useAgentSimulation works unchanged.
  */
-export function useEventHub() {
+export function useEventHub(options: UseEventHubOptions = {}) {
+  const { enabled = false, url } = options
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected')
   const pendingEventsRef = useRef<SimulationEvent[]>([])
   const [, setEventVersion] = useState(0)
@@ -19,10 +28,14 @@ export function useEventHub() {
   const selectedSessionIdRef = useRef<string | null>(null)
   const sessionEventsRef = useRef<Map<string, SimulationEvent[]>>(new Map())
   const [sessionsWithActivity, setSessionsWithActivity] = useState<Set<string>>(new Set())
+  const clientRef = useRef<ReturnType<typeof createEventHubClient>>(null)
 
   useEffect(() => {
-    const client = eventHubClient
+    if (!enabled) return
+
+    const client = createEventHubClient(url)
     if (!client) return
+    clientRef.current = client
 
     client.connect()
 
@@ -116,8 +129,10 @@ export function useEventHub() {
       unsubEvent()
       unsubSession()
       client.dispose()
+      clientRef.current = null
     }
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- url is stable from query param
+  }, [enabled, url])
 
   const consumeEvents = useCallback(() => {
     pendingEventsRef.current.length = 0
@@ -133,7 +148,7 @@ export function useEventHub() {
         next.delete(sessionId)
         return next
       })
-      eventHubClient?.selectSession(sessionId)
+      clientRef.current?.selectSession(sessionId)
     }
   }, [])
 

--- a/web/hooks/use-event-hub.ts
+++ b/web/hooks/use-event-hub.ts
@@ -1,0 +1,181 @@
+'use client'
+
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { eventHubClient, type HubSessionInfo } from '@/lib/event-hub-client'
+import type { SimulationEvent } from '@/lib/agent-types'
+import type { SessionInfo, ConnectionStatus } from '@/lib/vscode-bridge'
+
+/**
+ * React hook that connects to the agent-viz event hub via WebSocket.
+ * Returns the same shape as useVSCodeBridge so useAgentSimulation works unchanged.
+ */
+export function useEventHub() {
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected')
+  const pendingEventsRef = useRef<SimulationEvent[]>([])
+  const [, setEventVersion] = useState(0)
+
+  const [sessions, setSessions] = useState<SessionInfo[]>([])
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null)
+  const selectedSessionIdRef = useRef<string | null>(null)
+  const sessionEventsRef = useRef<Map<string, SimulationEvent[]>>(new Map())
+  const [sessionsWithActivity, setSessionsWithActivity] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    const client = eventHubClient
+    if (!client) return
+
+    client.connect()
+
+    const unsubStatus = client.onStatus((status) => {
+      setConnectionStatus(status)
+    })
+
+    const unsubEvent = client.onEvent((event: SimulationEvent) => {
+      // Buffer by session
+      if (event.sessionId) {
+        const buf = sessionEventsRef.current.get(event.sessionId) || []
+        buf.push(event)
+        sessionEventsRef.current.set(event.sessionId, buf)
+      }
+
+      // Deliver to pending if session matches
+      const selected = selectedSessionIdRef.current
+      if (event.type === 'agent_spawn') {
+        console.log('[use-event-hub] agent_spawn for', event.sessionId?.slice(0,8), 'selected:', selected?.slice(0,8), 'match:', event.sessionId === selected)
+      }
+      if (selected && event.sessionId === selected) {
+        pendingEventsRef.current.push(event)
+        setEventVersion(v => v + 1)
+      } else if (!selected) {
+        // No session selected yet — buffer but also push to pending
+        pendingEventsRef.current.push(event)
+        setEventVersion(v => v + 1)
+      } else if (event.sessionId && event.sessionId !== selected) {
+        setSessionsWithActivity(prev => {
+          if (prev.has(event.sessionId!)) return prev
+          const next = new Set(prev)
+          next.add(event.sessionId!)
+          return next
+        })
+      }
+    })
+
+    const unsubSession = client.onSession((type, data) => {
+      if (type === 'list') {
+        const listData = data as { sessions: HubSessionInfo[]; selectedSessionId?: string }
+        const hubSessions = Array.isArray(data) ? data as HubSessionInfo[] : listData.sessions
+        const preSelected = !Array.isArray(data) ? listData.selectedSessionId : undefined
+        const mapped: SessionInfo[] = hubSessions.map(s => ({
+          id: s.id,
+          label: s.label,
+          status: s.status as 'active' | 'completed',
+          startTime: s.startTime,
+          lastActivityTime: s.lastActivityTime,
+        }))
+        setSessions(mapped)
+        // Use hub's pre-selected session (it already sent event-batch for it)
+        if (!selectedSessionIdRef.current && mapped.length > 0) {
+          const autoId = preSelected || mapped[0].id
+          console.log('[use-event-hub] auto-selecting session:', autoId.slice(0, 8))
+          selectedSessionIdRef.current = autoId
+          setSelectedSessionId(autoId)
+        }
+      } else if (type === 'started') {
+        const session = data as HubSessionInfo
+        const mapped: SessionInfo = {
+          id: session.id,
+          label: session.label,
+          status: session.status as 'active' | 'completed',
+          startTime: session.startTime,
+          lastActivityTime: session.lastActivityTime,
+        }
+        setSessions(prev => {
+          if (prev.find(s => s.id === session.id)) return prev
+          return [...prev, mapped]
+        })
+        // Auto-select only if no session is currently selected
+        if (!selectedSessionIdRef.current) {
+          selectedSessionIdRef.current = session.id
+          setSelectedSessionId(session.id)
+        }
+      } else if (type === 'updated') {
+        const { sessionId, label } = data as { sessionId: string; label: string }
+        setSessions(prev => prev.map(s =>
+          s.id === sessionId ? { ...s, label } : s
+        ))
+      } else if (type === 'ended') {
+        const sessionId = data as string
+        setSessions(prev => prev.map(s =>
+          s.id === sessionId ? { ...s, status: 'completed' as const } : s
+        ))
+      }
+    })
+
+    return () => {
+      unsubStatus()
+      unsubEvent()
+      unsubSession()
+      client.dispose()
+    }
+  }, [])
+
+  const consumeEvents = useCallback(() => {
+    pendingEventsRef.current.length = 0
+  }, [])
+
+  const selectSession = useCallback((sessionId: string | null) => {
+    selectedSessionIdRef.current = sessionId
+    setSelectedSessionId(sessionId)
+    if (sessionId) {
+      setSessionsWithActivity(prev => {
+        if (!prev.has(sessionId)) return prev
+        const next = new Set(prev)
+        next.delete(sessionId)
+        return next
+      })
+      eventHubClient?.selectSession(sessionId)
+    }
+  }, [])
+
+  const flushSessionEvents = useCallback((sessionId: string, fromIndex = 0) => {
+    const buffered = sessionEventsRef.current.get(sessionId) || []
+    pendingEventsRef.current.length = 0
+    pendingEventsRef.current.push(...buffered.slice(fromIndex))
+    setEventVersion(v => v + 1)
+  }, [])
+
+  const getSessionEventCount = useCallback((sessionId: string): number => {
+    return sessionEventsRef.current.get(sessionId)?.length ?? 0
+  }, [])
+
+  const removeSession = useCallback((sessionId: string) => {
+    setSessions(prev => prev.filter(s => s.id !== sessionId))
+    setSessionsWithActivity(prev => {
+      if (!prev.has(sessionId)) return prev
+      const next = new Set(prev)
+      next.delete(sessionId)
+      return next
+    })
+  }, [])
+
+  const bridgeOpenFile = useCallback((_filePath: string, _line?: number) => {
+    // No-op in standalone mode — could open in browser or copy to clipboard
+  }, [])
+
+  return {
+    isVSCode: false,
+    connectionStatus,
+    pendingEvents: pendingEventsRef.current as readonly SimulationEvent[],
+    consumeEvents,
+    useMockData: false, // Never show mock data — we always use hub events
+    bridgeOpenFile,
+    sessions,
+    selectedSessionId,
+    selectedSessionIdRef,
+    selectSession,
+    flushSessionEvents,
+    getSessionEventCount,
+    sessionsWithActivity,
+    removeSession,
+  }
+}

--- a/web/lib/event-hub-client.ts
+++ b/web/lib/event-hub-client.ts
@@ -1,0 +1,167 @@
+/**
+ * WebSocket client singleton for connecting to the agent-viz event hub.
+ * Mirrors the structure of vscode-bridge.ts for consistent API.
+ */
+
+import type { SimulationEvent } from './agent-types'
+
+export interface HubSessionInfo {
+  id: string
+  label: string
+  status: 'active' | 'completed'
+  startTime: number
+  lastActivityTime: number
+}
+
+type EventCallback = (event: SimulationEvent) => void
+type StatusCallback = (status: 'connected' | 'disconnected' | 'watching') => void
+type SessionCallback = (
+  type: 'list' | 'started' | 'ended' | 'updated' | 'reset',
+  data: unknown
+) => void
+
+class EventHubClient {
+  private ws: WebSocket | null = null
+  private eventListeners: EventCallback[] = []
+  private statusListeners: StatusCallback[] = []
+  private sessionListeners: SessionCallback[] = []
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectDelay = 1000
+  private maxReconnectDelay = 10000
+  private url: string
+
+  constructor(url = 'ws://localhost:7850/ws') {
+    this.url = url
+  }
+
+  connect() {
+    if (this.ws && (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN)) {
+      return
+    }
+
+    this.notifyStatus('watching')
+
+    try {
+      this.ws = new WebSocket(this.url)
+    } catch {
+      this.scheduleReconnect()
+      return
+    }
+
+    this.ws.onopen = () => {
+      console.log('[event-hub] Connected to', this.url)
+      this.reconnectDelay = 1000
+      this.notifyStatus('connected')
+    }
+
+    this.ws.onmessage = (ev) => {
+      try {
+        const raw = ev.data as string
+        console.log('[event-hub] raw msg type:', raw.slice(0, 50))
+        const msg = JSON.parse(raw)
+        this.handleMessage(msg)
+      } catch (err) {
+        console.error('[event-hub] message parse error:', err, 'data length:', (ev.data as string)?.length)
+      }
+    }
+
+    this.ws.onclose = () => {
+      console.log('[event-hub] Disconnected')
+      this.notifyStatus('disconnected')
+      this.scheduleReconnect()
+    }
+
+    this.ws.onerror = () => {
+      // onclose will fire after this
+    }
+  }
+
+  private handleMessage(msg: Record<string, unknown>) {
+    switch (msg.type) {
+      case 'event': {
+        const event = msg.event as SimulationEvent
+        console.log('[event-hub] event:', event?.type, event?.sessionId?.slice(0, 8))
+        if (event) this.eventListeners.forEach(cb => cb(event))
+        break
+      }
+      case 'event-batch': {
+        const events = msg.events as SimulationEvent[]
+        console.log('[event-hub] event-batch:', events?.length, 'events')
+        if (Array.isArray(events)) {
+          events.forEach(event => this.eventListeners.forEach(cb => cb(event)))
+        }
+        break
+      }
+      case 'session-list': {
+        const sessions = msg.sessions as HubSessionInfo[]
+        const preSelected = msg.selectedSessionId as string | undefined
+        console.log('[event-hub] session-list:', sessions?.length, 'sessions, preSelected:', preSelected?.slice(0, 8))
+        this.sessionListeners.forEach(cb => cb('list', { sessions, selectedSessionId: preSelected }))
+        break
+      }
+      case 'session-started': {
+        this.sessionListeners.forEach(cb => cb('started', msg.session))
+        break
+      }
+      case 'session-ended': {
+        this.sessionListeners.forEach(cb => cb('ended', msg.sessionId))
+        break
+      }
+      case 'session-updated': {
+        this.sessionListeners.forEach(cb => cb('updated', {
+          sessionId: msg.sessionId,
+          label: msg.label,
+        }))
+        break
+      }
+      case 'connection-status': {
+        // Hub confirms connection
+        break
+      }
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer) return
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.reconnectDelay = Math.min(this.reconnectDelay * 1.5, this.maxReconnectDelay)
+      this.connect()
+    }, this.reconnectDelay)
+  }
+
+  private notifyStatus(status: 'connected' | 'disconnected' | 'watching') {
+    this.statusListeners.forEach(cb => cb(status))
+  }
+
+  onEvent(cb: EventCallback): () => void {
+    this.eventListeners.push(cb)
+    return () => { this.eventListeners = this.eventListeners.filter(l => l !== cb) }
+  }
+
+  onStatus(cb: StatusCallback): () => void {
+    this.statusListeners.push(cb)
+    return () => { this.statusListeners = this.statusListeners.filter(l => l !== cb) }
+  }
+
+  onSession(cb: SessionCallback): () => void {
+    this.sessionListeners.push(cb)
+    return () => { this.sessionListeners = this.sessionListeners.filter(l => l !== cb) }
+  }
+
+  selectSession(sessionId: string) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: 'select-session', sessionId }))
+    }
+  }
+
+  dispose() {
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    if (this.ws) this.ws.close()
+    this.eventListeners = []
+    this.statusListeners = []
+    this.sessionListeners = []
+  }
+}
+
+export const eventHubClient = typeof window !== 'undefined' ? new EventHubClient() : null

--- a/web/lib/event-hub-client.ts
+++ b/web/lib/event-hub-client.ts
@@ -164,4 +164,11 @@ class EventHubClient {
   }
 }
 
-export const eventHubClient = typeof window !== 'undefined' ? new EventHubClient() : null
+/** Create a new client instance. Call connect() to start. */
+export function createEventHubClient(url?: string) {
+  if (typeof window === 'undefined') return null
+  return new EventHubClient(url)
+}
+
+/** @deprecated Use createEventHubClient() instead */
+export const eventHubClient = createEventHubClient()

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,2722 @@
+{
+    "name": "agent-flow-web",
+    "version": "0.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "agent-flow-web",
+            "version": "0.1.0",
+            "dependencies": {
+                "@vercel/analytics": "1.6.1",
+                "concurrently": "^9.2.1",
+                "d3-force": "^3.0.0",
+                "next": "16.1.6",
+                "react": "19.2.4",
+                "react-dom": "19.2.4",
+                "ws": "^8.20.0"
+            },
+            "devDependencies": {
+                "@tailwindcss/postcss": "^4.2.0",
+                "@tailwindcss/vite": "^4.2.2",
+                "@types/d3-force": "^3.0.10",
+                "@types/node": "^22",
+                "@types/react": "19.2.14",
+                "@types/react-dom": "19.2.3",
+                "@vitejs/plugin-react": "^6.0.1",
+                "postcss": "^8.5",
+                "tailwindcss": "^4.2.0",
+                "tw-animate-css": "1.3.3",
+                "typescript": "5.7.3",
+                "vite": "^8.0.1"
+            }
+        },
+        "node_modules/@alloc/quick-lru": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+            "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.7.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@next/env": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
+            "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+            "license": "MIT"
+        },
+        "node_modules/@next/swc-darwin-arm64": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+            "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-darwin-x64": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+            "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-arm64-gnu": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+            "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-arm64-musl": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+            "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-x64-gnu": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+            "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-x64-musl": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+            "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-arm64-msvc": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+            "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-x64-msvc": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+            "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+            "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+            "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+            "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+            "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+            "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+            "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+            "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+            "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+            "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+            "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+            "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@tailwindcss/node": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+            "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "enhanced-resolve": "^5.19.0",
+                "jiti": "^2.6.1",
+                "lightningcss": "1.32.0",
+                "magic-string": "^0.30.21",
+                "source-map-js": "^1.2.1",
+                "tailwindcss": "4.2.2"
+            }
+        },
+        "node_modules/@tailwindcss/oxide": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+            "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "optionalDependencies": {
+                "@tailwindcss/oxide-android-arm64": "4.2.2",
+                "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+                "@tailwindcss/oxide-darwin-x64": "4.2.2",
+                "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+                "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+                "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-android-arm64": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+            "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-arm64": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+            "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-x64": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+            "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-freebsd-x64": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+            "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+            "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+            "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+            "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+            "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+            "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+            "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+            "bundleDependencies": [
+                "@napi-rs/wasm-runtime",
+                "@emnapi/core",
+                "@emnapi/runtime",
+                "@tybys/wasm-util",
+                "@emnapi/wasi-threads",
+                "tslib"
+            ],
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.8.1",
+                "@emnapi/runtime": "^1.8.1",
+                "@emnapi/wasi-threads": "^1.1.0",
+                "@napi-rs/wasm-runtime": "^1.1.1",
+                "@tybys/wasm-util": "^0.10.1",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+            "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+            "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/postcss": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
+            "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@alloc/quick-lru": "^5.2.0",
+                "@tailwindcss/node": "4.2.2",
+                "@tailwindcss/oxide": "4.2.2",
+                "postcss": "^8.5.6",
+                "tailwindcss": "4.2.2"
+            }
+        },
+        "node_modules/@tailwindcss/vite": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+            "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tailwindcss/node": "4.2.2",
+                "@tailwindcss/oxide": "4.2.2",
+                "tailwindcss": "4.2.2"
+            },
+            "peerDependencies": {
+                "vite": "^5.2.0 || ^6 || ^7 || ^8"
+            }
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/d3-force": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+            "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "22.19.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+            "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/@types/react": {
+            "version": "19.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+            "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^19.2.0"
+            }
+        },
+        "node_modules/@vercel/analytics": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+            "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+            "license": "MPL-2.0",
+            "peerDependencies": {
+                "@remix-run/react": "^2",
+                "@sveltejs/kit": "^1 || ^2",
+                "next": ">= 13",
+                "react": "^18 || ^19 || ^19.0.0-rc",
+                "svelte": ">= 4",
+                "vue": "^3",
+                "vue-router": "^4"
+            },
+            "peerDependenciesMeta": {
+                "@remix-run/react": {
+                    "optional": true
+                },
+                "@sveltejs/kit": {
+                    "optional": true
+                },
+                "next": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "svelte": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                },
+                "vue-router": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitejs/plugin-react": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+            "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "1.0.0-rc.7"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+                "babel-plugin-react-compiler": "^1.0.0",
+                "vite": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@rolldown/plugin-babel": {
+                    "optional": true
+                },
+                "babel-plugin-react-compiler": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.10",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
+            "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001781",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+            "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/client-only": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+            "license": "MIT"
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
+        },
+        "node_modules/concurrently": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+            "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "4.1.2",
+                "rxjs": "7.8.2",
+                "shell-quote": "1.8.3",
+                "supports-color": "8.1.1",
+                "tree-kill": "1.2.2",
+                "yargs": "17.7.2"
+            },
+            "bin": {
+                "conc": "dist/bin/concurrently.js",
+                "concurrently": "dist/bin/concurrently.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/d3-dispatch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-force": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-quadtree": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-quadtree": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.20.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+            "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jiti": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/next": {
+            "version": "16.1.6",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
+            "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+            "license": "MIT",
+            "dependencies": {
+                "@next/env": "16.1.6",
+                "@swc/helpers": "0.5.15",
+                "baseline-browser-mapping": "^2.8.3",
+                "caniuse-lite": "^1.0.30001579",
+                "postcss": "8.4.31",
+                "styled-jsx": "5.1.6"
+            },
+            "bin": {
+                "next": "dist/bin/next"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "optionalDependencies": {
+                "@next/swc-darwin-arm64": "16.1.6",
+                "@next/swc-darwin-x64": "16.1.6",
+                "@next/swc-linux-arm64-gnu": "16.1.6",
+                "@next/swc-linux-arm64-musl": "16.1.6",
+                "@next/swc-linux-x64-gnu": "16.1.6",
+                "@next/swc-linux-x64-musl": "16.1.6",
+                "@next/swc-win32-arm64-msvc": "16.1.6",
+                "@next/swc-win32-x64-msvc": "16.1.6",
+                "sharp": "^0.34.4"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.1.0",
+                "@playwright/test": "^1.51.1",
+                "babel-plugin-react-compiler": "*",
+                "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+                "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+                "sass": "^1.3.0"
+            },
+            "peerDependenciesMeta": {
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@playwright/test": {
+                    "optional": true
+                },
+                "babel-plugin-react-compiler": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/next/node_modules/postcss": {
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.6",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/react": {
+            "version": "19.2.4",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+            "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "19.2.4",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.27.0"
+            },
+            "peerDependencies": {
+                "react": "^19.2.4"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+            "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.122.0",
+                "@rolldown/pluginutils": "1.0.0-rc.11"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+            }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+            "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "license": "MIT"
+        },
+        "node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "license": "ISC",
+            "optional": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/sharp": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/styled-jsx": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+            "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+            "license": "MIT",
+            "dependencies": {
+                "client-only": "0.0.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                },
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/tailwindcss": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+            "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tapable": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+            "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/tw-animate-css": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.3.tgz",
+            "integrity": "sha512-tXE2TRWrskc4TU3RDd7T8n8Np/wCfoeH9gz22c7PzYqNPQ9FBGFbWWzwL0JyHcFp+jHozmF76tbHfPAx22ua2Q==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Wombosvideo"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vite": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+            "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.11",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        }
+    }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,32 +1,35 @@
 {
-  "name": "agent-flow-web",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "build:webview": "vite build --config vite.config.webview.ts"
-  },
-  "dependencies": {
-    "@vercel/analytics": "1.6.1",
-    "d3-force": "^3.0.0",
-    "next": "16.1.6",
-    "react": "19.2.4",
-    "react-dom": "19.2.4"
-  },
-  "devDependencies": {
-    "@tailwindcss/postcss": "^4.2.0",
-    "@tailwindcss/vite": "^4.2.2",
-    "@types/d3-force": "^3.0.10",
-    "@types/node": "^22",
-    "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
-    "@vitejs/plugin-react": "^6.0.1",
-    "postcss": "^8.5",
-    "tailwindcss": "^4.2.0",
-    "tw-animate-css": "1.3.3",
-    "typescript": "5.7.3",
-    "vite": "^8.0.1"
-  }
+    "name": "agent-flow-web",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev",
+        "build": "next build",
+        "start": "next start",
+        "build:webview": "vite build --config vite.config.webview.ts",
+        "dev:standalone": "concurrently \"next dev\" \"node hook-server.mjs\""
+    },
+    "dependencies": {
+        "@vercel/analytics": "1.6.1",
+        "concurrently": "^9.2.1",
+        "d3-force": "^3.0.0",
+        "next": "16.1.6",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "ws": "^8.20.0"
+    },
+    "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.0",
+        "@tailwindcss/vite": "^4.2.2",
+        "@types/d3-force": "^3.0.10",
+        "@types/node": "^22",
+        "@types/react": "19.2.14",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "^6.0.1",
+        "postcss": "^8.5",
+        "tailwindcss": "^4.2.0",
+        "tw-animate-css": "1.3.3",
+        "typescript": "5.7.3",
+        "vite": "^8.0.1"
+    }
 }


### PR DESCRIPTION
## Summary

Adds **standalone mode** so Agent Flow works as a plain web app — without VS Code — driven by [OpenClaw](https://openclaw.dev) or Claude Code CLI.

- `localhost:3000` → VS Code extension (default, unchanged)
- `localhost:3000?mode=openclaw` → OpenClaw mode via event hub
- `localhost:3000?mode=claude-code` → Claude Code CLI via event hub

## What's new

### Event hub architecture (all new files, no changes to existing VS Code flow)

```
Agent runtime (OpenClaw / Claude Code hooks)
        │  HTTP POST :7842
        ▼
  hook-server.mjs     ← translates hook events → SimulationEvents
        │  WebSocket :7850/ws
        ▼
  Next.js browser     ← renders live visualization
```

### New files
- **`web/hook-server.mjs`** — Dual-port server: HTTP :7842 receives hook events, WebSocket :7850 streams SimulationEvents to browser
- **`web/lib/event-hub-client.ts`** — WebSocket client with exponential backoff reconnect
- **`web/hooks/use-event-hub.ts`** — React hook (same shape as `useVSCodeBridge`)
- **`scripts/openclaw-bridge.mjs`** — Tails OpenClaw session JSONL, forwards events to hook server

### Changes to existing files (minimal, backward-compatible)

| File | Change | Impact on VS Code mode |
|------|--------|----------------------|
| `index.tsx` | Read `?mode=` param, use event hub when set | **None** — default path unchanged |
| `use-agent-simulation.ts` | Fix React StrictMode double-invocation bug | **Positive** — fixes edge case for everyone |
| `handle-message-events.ts` | Only rename agent if name is `'Orchestrator'` | **None** — VS Code default IS "Orchestrator" |

### Design decisions
- **`?mode=` gating**: Event hub is never instantiated without the query param. Zero overhead in VS Code mode — no WebSocket connection, no extra hook state.
- **No `reactStrictMode: false`**: The `use-agent-simulation.ts` fix properly handles StrictMode's double-invocation, so we don't need to disable it.
- **Extensible**: Adding new modes (`?mode=codex`, `?mode=gemini`) only requires a new bridge script — the hub protocol is agent-agnostic.

## Quick start (OpenClaw)

```bash
cd web && npm install
npm run dev:standalone          # starts Next.js + hook server
node scripts/openclaw-bridge.mjs  # in another terminal
# open http://localhost:3000?mode=openclaw
```

## Test plan
- [ ] `localhost:3000` (no param) — VS Code mode works identically to upstream
- [ ] `localhost:3000?mode=openclaw` — connects to event hub, shows OpenClaw agent activity
- [ ] React StrictMode enabled — agents render correctly (no "0 agents" bug)
- [ ] Session switching between tabs works in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)