### PR TITLE
chore: Add VS Code debug and dev configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ next-env.d.ts
 
 # Local IDE config
 extension/.vscode/
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
+!.vscode/settings.json
 
 # Claude Code
 .claude/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/extension"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/extension/dist/**/*.js"
+      ],
+      "preLaunchTask": "watch-extension"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "agentVisualizer.devServerPort": 3000
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "watch-extension",
+      "type": "npm",
+      "script": "watch",
+      "path": "extension",
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": {
+          "regexp": "^✘ \\[ERROR\\] (.+)",
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^\\[watch\\]",
+          "endsPattern": "^Watching for changes\\.\\.\\."
+        }
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Add launch.json for extension debugging from the workspace root, tasks.json with esbuild watch problem matcher, and settings.json with devServerPort for webview hot reload.

## How to test
You should be able to run the extension debugger from the monorepo root without having to cd to the `extension` folder
<img width="247" height="78" alt="image" src="https://github.com/user-attachments/assets/c829dcbe-7b47-4554-8ebf-b379d3ff6856" />


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)
