### PR TITLE
fix: Fix event loss from React strict mode double-invocation

### DIFF
--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -222,9 +222,21 @@ export function AgentVisualizer() {
     bridge.bridgeOpenFile(filePath, line)
   }, [bridge])
 
+  const isEmpty = agents.size === 0 && !bridge.useMockData
+
   return (
     <OpenFileProvider value={bridge.isVSCode ? openFile : null}>
     <div className="h-screen w-screen relative overflow-hidden" style={{ background: COLORS.void }}>
+      {/* Empty state when no demo and no live data */}
+      {isEmpty && (
+        <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
+          <div className="text-center" style={{ fontFamily: "'SF Mono', 'Fira Code', monospace" }}>
+            <div className="text-sm" style={{ color: '#66ccff80' }}>WAITING FOR AGENT SESSION</div>
+            <div className="mt-2 text-xs" style={{ color: '#66ccff40' }}>Start a Claude Code session to see activity</div>
+          </div>
+        </div>
+      )}
+
       {/* Canvas fills everything */}
       <AgentCanvas
         agents={agents}

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -166,8 +166,18 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     const deltaTime = Math.min((timestamp - lastTimeRef.current) / 1000, ANIM_SPEED.maxDeltaTime)
     lastTimeRef.current = timestamp
 
+    // Snapshot and consume external events OUTSIDE setState to avoid
+    // React strict mode double-invocation clearing them on the first call
+    let capturedEvents: SimulationEvent[] | null = null
+    if (externalEvents && externalEvents.length > 0 && !useMockData) {
+      capturedEvents = externalEvents.slice()
+      onExternalEventsConsumed?.()
+    }
+
     setState(prev => {
-      if (!prev.isPlaying) return prev
+      if (!prev.isPlaying) {
+        return prev
+      }
 
       let newTime = prev.currentTime + deltaTime * prev.speed
       let maxT = Math.max(prev.maxTimeReached, newTime)
@@ -198,27 +208,16 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
         }
       }
 
-      // Process NEW external events (from VS Code bridge)
-      // Copy and clear immediately to prevent stale closures from
-      // reprocessing the same events across multiple animation frames
-      if (externalEvents && externalEvents.length > 0) {
-        const eventsToProcess = externalEvents.slice()
-        onExternalEventsConsumed?.()
-        for (const event of eventsToProcess) {
-          // Filter by session if specified — use ref so we always read the
-          // latest value even if the animate closure hasn't been recreated yet.
-          // The ref is also updated synchronously via onSessionFilterChange callback
-          // so it's current even before React re-renders.
+      // Process captured external events (snapshotted outside setState
+      // to avoid React strict mode double-invocation issues)
+      if (capturedEvents) {
+        for (const event of capturedEvents) {
           const activeFilter = sessionFilterRef.current
           if (activeFilter && event.sessionId && event.sessionId !== activeFilter) {
             continue
           }
-          // Clamp event time to at least the current sim time so that
-          // bubbles/effects created by this event appear fresh, not pre-aged
           const eventTime = Math.max(event.time || newTime, newTime)
           const timedEvent = { ...event, time: eventTime }
-          // Advance currentTime so processEvent sees correct timestamps
-          // (critical for session-switch replay where many events arrive at once)
           currentState = { ...currentState, currentTime: eventTime }
           currentState = processEventWithContext(timedEvent, currentState)
           newEvents.push(timedEvent)


### PR DESCRIPTION
## What does this PR do?

React strict mode (development) calls setState updater functions twice, discarding the first result. The animate callback had a side effect (onExternalEventsConsumed) inside setState that cleared the events array on the first call, leaving the second call with nothing to process.

Fix: snapshot and consume external events outside setState so both invocations see the same captured events.

Also adds an empty state UI when no agents are active and no demo is running.

## How to test

1. When the web simulator loads and there are no agents. It should show the text that there are no agents and that the user should start a session.
2. Events should be processed and should show in the UI like normal.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)
