### PR TITLE
Fix heavy performance degradation in long sessions (#20)

### DIFF
--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useRef, useEffect, useState, useCallback } from 'react'
-import { Agent, ToolCallNode, Particle, Edge, Discovery, DepthParticle } from '@/lib/agent-types'
+import { Agent, Particle, Edge, Discovery, DepthParticle } from '@/lib/agent-types'
+import type { SimulationState } from '@/hooks/simulation/types'
 import { getStateColor } from '@/lib/colors'
-import { ANIM_SPEED } from '@/lib/canvas-constants'
+import { ANIM_SPEED, PERF_OVERLAY, PERF_OVERLAY_ENABLED } from '@/lib/canvas-constants'
 import { BloomRenderer } from './bloom-renderer'
 import { createDepthParticles, updateDepthParticles, drawBackground } from './background-layer'
 import {
@@ -23,11 +24,8 @@ import { useCanvasCamera } from '@/hooks/use-canvas-camera'
 import { useCanvasInteraction } from '@/hooks/use-canvas-interaction'
 
 interface CanvasProps {
-  agents: Map<string, Agent>
-  toolCalls: Map<string, ToolCallNode>
-  particles: Particle[]
-  edges: Edge[]
-  discoveries: Discovery[]
+  /** Ref to simulation state — read every frame without React re-renders */
+  simulationRef: React.RefObject<SimulationState>
   selectedAgentId: string | null
   hoveredAgentId: string | null
   showStats: boolean
@@ -42,14 +40,13 @@ interface CanvasProps {
   selectedToolCallId?: string | null
   onDiscoveryClick?: (discoveryId: string | null) => void
   selectedDiscoveryId?: string | null
-  currentTime?: number
   showCostOverlay?: boolean
 }
 
 export function AgentCanvas({
-  agents, toolCalls, particles, edges, discoveries,
+  simulationRef,
   selectedAgentId, hoveredAgentId, showStats, showHexGrid, zoomToFitTrigger, pauseAutoFit,
-  onAgentClick, onAgentHover, onAgentDrag, onContextMenu, onToolCallClick, selectedToolCallId, onDiscoveryClick, selectedDiscoveryId, currentTime: simTime, showCostOverlay,
+  onAgentClick, onAgentHover, onAgentDrag, onContextMenu, onToolCallClick, selectedToolCallId, onDiscoveryClick, selectedDiscoveryId, showCostOverlay,
 }: CanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const mainCanvasRef = useRef<HTMLCanvasElement>(null)
@@ -70,6 +67,16 @@ export function AgentCanvas({
   // Rate-limited error logging for the draw loop (avoid flooding console)
   const lastDrawErrorRef = useRef(0)
 
+  // Performance overlay state
+  const perfRef = useRef({
+    frames: 0,
+    lastFpsUpdate: 0,
+    fps: 0,
+    frameTimeMs: 0,
+    frameTimes: [] as number[],
+    p95: 0,
+  })
+
   // Caches for per-frame lookups — avoid rebuilding Set/Map every ~16ms
   const edgeLookupCacheRef = useRef<{
     particles: Particle[]
@@ -79,11 +86,15 @@ export function AgentCanvas({
   }>({ particles: [], edges: [], activeEdgeIds: new Set(), edgeMap: new Map() })
 
   // ─── Stable refs for animation loop & event handlers ────────────────────
+  // Simulation data (agents, particles, etc.) is synced from simulationRef
+  // at the top of each draw frame, so it's always fresh even without re-renders.
+  const sim = simulationRef.current
   const makeDrawProps = (prev?: { isDragging: boolean }) => ({
-    agents, toolCalls, particles, edges, discoveries,
+    agents: sim.agents, toolCalls: sim.toolCalls,
+    particles: sim.particles, edges: sim.edges, discoveries: sim.discoveries,
     selectedAgentId, hoveredAgentId, showStats, showHexGrid,
     showCostOverlay, selectedToolCallId, selectedDiscoveryId,
-    simTime, pauseAutoFit, dimensions,
+    simTime: sim.currentTime, pauseAutoFit, dimensions,
     onAgentDrag, onAgentClick, onAgentHover, onContextMenu,
     onToolCallClick, onDiscoveryClick,
     isDragging: prev?.isDragging ?? false,
@@ -97,7 +108,7 @@ export function AgentCanvas({
     screenToCanvas, doZoomToFit, updateCamera,
   } = useCanvasCamera({
     mainCanvasRef, drawPropsRef, simTimeRef, dimensions,
-    agentCount: agents.size, zoomToFitTrigger, selectedAgentId,
+    agentCount: sim.agents.size, zoomToFitTrigger, selectedAgentId,
   })
 
   // ─── Interaction ────────────────────────────────────────────────────────
@@ -165,102 +176,150 @@ export function AgentCanvas({
     if (!ctx) return
 
     try {
-    const {
-      agents, toolCalls, particles, edges, discoveries,
-      selectedAgentId, hoveredAgentId, showStats, showHexGrid,
-      showCostOverlay, selectedToolCallId, selectedDiscoveryId,
-      simTime, pauseAutoFit, dimensions, onAgentDrag,
-      isDragging,
-    } = drawPropsRef.current
-    const transform = transformRef.current
+      // Sync simulation data from ref — always fresh, independent of React renders
+      {
+        const s = simulationRef.current
+        const p = drawPropsRef.current
+        p.agents = s.agents
+        p.toolCalls = s.toolCalls
+        p.particles = s.particles
+        p.edges = s.edges
+        p.discoveries = s.discoveries
+        p.simTime = s.currentTime
+      }
 
-    const deltaTime = lastFrameTimeRef.current ? (timestamp - lastFrameTimeRef.current) / 1000 : ANIM_SPEED.defaultDeltaTime
-    lastFrameTimeRef.current = timestamp
-    timeRef.current += deltaTime
-    if (simTime != null) simTimeRef.current = simTime
+      const {
+        agents, toolCalls, particles, edges, discoveries,
+        selectedAgentId, hoveredAgentId, showStats, showHexGrid,
+        showCostOverlay, selectedToolCallId, selectedDiscoveryId,
+        simTime, pauseAutoFit, dimensions, onAgentDrag,
+        isDragging,
+      } = drawPropsRef.current
+      const transform = transformRef.current
 
-    const dpr = dprRef.current
-    const w = dimensions.width
-    const h = dimensions.height
+      const deltaTime = lastFrameTimeRef.current ? (timestamp - lastFrameTimeRef.current) / 1000 : ANIM_SPEED.defaultDeltaTime
+      lastFrameTimeRef.current = timestamp
+      timeRef.current += deltaTime
+      if (simTime != null) simTimeRef.current = simTime
 
-    if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
-      canvas.width = w * dpr
-      canvas.height = h * dpr
-      ctx.scale(dpr, dpr)
-    }
+      const dpr = dprRef.current
+      const w = dimensions.width
+      const h = dimensions.height
 
-    // Camera physics (inertia + auto-fit)
-    updateCamera(isDragging, pauseAutoFit)
+      if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
+        canvas.width = w * dpr
+        canvas.height = h * dpr
+        ctx.scale(dpr, dpr)
+      }
 
-    // Floaty agent drag
-    updateDragLerp(agents, onAgentDrag)
+      // Camera physics (inertia + auto-fit)
+      updateCamera(isDragging, pauseAutoFit)
 
-    // Detect state changes → visual effects
-    detectStateChanges()
+      // Floaty agent drag
+      updateDragLerp(agents, onAgentDrag)
 
-    // Update effects (mutate in place to avoid GC pressure)
-    {
-      const effects = effectsRef.current
-      let writeIdx = 0
-      for (let i = 0; i < effects.length; i++) {
-        effects[i].age += deltaTime
-        if (effects[i].age < effects[i].duration) {
-          if (writeIdx !== i) effects[writeIdx] = effects[i]
-          writeIdx++
+      // Detect state changes → visual effects
+      detectStateChanges()
+
+      // Update effects (mutate in place to avoid GC pressure)
+      {
+        const effects = effectsRef.current
+        let writeIdx = 0
+        for (let i = 0; i < effects.length; i++) {
+          effects[i].age += deltaTime
+          if (effects[i].age < effects[i].duration) {
+            if (writeIdx !== i) effects[writeIdx] = effects[i]
+            writeIdx++
+          }
+        }
+        effects.length = writeIdx
+      }
+
+      ctx.clearRect(0, 0, w, h)
+      updateDepthParticles(depthParticlesRef.current, deltaTime, w, h)
+
+      let activeAgentPos: { x: number; y: number; color: string } | undefined
+      for (const [, agent] of agents) {
+        if (agent.state === 'thinking' || agent.state === 'tool_calling' || agent.state === 'waiting_permission') {
+          activeAgentPos = { x: agent.x, y: agent.y, color: getStateColor(agent.state) }
+          break
         }
       }
-      effects.length = writeIdx
-    }
 
-    ctx.clearRect(0, 0, w, h)
-    updateDepthParticles(depthParticlesRef.current, deltaTime, w, h)
+      drawBackground(ctx, w, h, depthParticlesRef.current, transform, showHexGrid, timeRef.current, activeAgentPos)
 
-    let activeAgentPos: { x: number; y: number; color: string } | undefined
-    for (const [, agent] of agents) {
-      if (agent.state === 'thinking' || agent.state === 'tool_calling' || agent.state === 'waiting_permission') {
-        activeAgentPos = { x: agent.x, y: agent.y, color: getStateColor(agent.state) }
-        break
+      ctx.save()
+      ctx.translate(transform.x, transform.y)
+      ctx.scale(transform.scale, transform.scale)
+
+      // Pre-compute shared lookup structures — cached across frames when inputs are unchanged
+      const elCache = edgeLookupCacheRef.current
+      let activeEdgeIds: Set<string>
+      let edgeMap: Map<string, Edge>
+      if (elCache.particles === particles && elCache.edges === edges) {
+        activeEdgeIds = elCache.activeEdgeIds
+        edgeMap = elCache.edgeMap
+      } else {
+        activeEdgeIds = getActiveEdgeIds(particles)
+        edgeMap = buildEdgeMap(edges)
+        edgeLookupCacheRef.current = { particles, edges, activeEdgeIds, edgeMap }
       }
-    }
 
-    drawBackground(ctx, w, h, depthParticlesRef.current, transform, showHexGrid, timeRef.current, activeAgentPos)
+      drawDiscoveryConnections(ctx, discoveries, agents)
+      drawEdges(ctx, edges, agents, toolCalls, activeEdgeIds, timeRef.current)
+      drawToolCalls(ctx, toolCalls, timeRef.current, selectedToolCallId)
+      drawDiscoveries(ctx, discoveries, agents, selectedDiscoveryId)
+      drawAgents(ctx, agents, selectedAgentId, hoveredAgentId, showStats, timeRef.current)
+      drawMessageBubblesWorld(ctx, agents, simTimeRef.current)
+      if (showCostOverlay) drawCostLabels(ctx, agents, toolCalls)
+      drawParticles(ctx, particles, edgeMap, agents, toolCalls, timeRef.current)
+      drawEffects(ctx, effectsRef.current)
 
-    ctx.save()
-    ctx.translate(transform.x, transform.y)
-    ctx.scale(transform.scale, transform.scale)
+      if (selectedAgentId) {
+        const agent = agents.get(selectedAgentId)
+        if (agent) drawTetherLine(ctx, agent, transform, h)
+      }
 
-    // Pre-compute shared lookup structures — cached across frames when inputs are unchanged
-    const elCache = edgeLookupCacheRef.current
-    let activeEdgeIds: Set<string>
-    let edgeMap: Map<string, Edge>
-    if (elCache.particles === particles && elCache.edges === edges) {
-      activeEdgeIds = elCache.activeEdgeIds
-      edgeMap = elCache.edgeMap
-    } else {
-      activeEdgeIds = getActiveEdgeIds(particles)
-      edgeMap = buildEdgeMap(edges)
-      edgeLookupCacheRef.current = { particles, edges, activeEdgeIds, edgeMap }
-    }
+      ctx.restore()
 
-    drawDiscoveryConnections(ctx, discoveries, agents)
-    drawEdges(ctx, edges, agents, toolCalls, activeEdgeIds, timeRef.current)
-    drawToolCalls(ctx, toolCalls, timeRef.current, selectedToolCallId)
-    drawDiscoveries(ctx, discoveries, agents, selectedDiscoveryId)
-    drawAgents(ctx, agents, selectedAgentId, hoveredAgentId, showStats, timeRef.current)
-    drawMessageBubblesWorld(ctx, agents, simTimeRef.current)
-    if (showCostOverlay) drawCostLabels(ctx, agents, toolCalls)
-    drawParticles(ctx, particles, edgeMap, agents, toolCalls, timeRef.current)
-    drawEffects(ctx, effectsRef.current)
+      if (showCostOverlay) drawCostSummaryPanel(ctx, agents, toolCalls)
+      if (bloomRef.current) bloomRef.current.apply(canvas, ctx)
 
-    if (selectedAgentId) {
-      const agent = agents.get(selectedAgentId)
-      if (agent) drawTetherLine(ctx, agent, transform, h)
-    }
+      // ─── Performance overlay (enabled via ?perf or ?stress) ──────────
+      if (PERF_OVERLAY_ENABLED) {
+        const perf = perfRef.current
+        const frameEnd = performance.now()
+        const frameMs = frameEnd - (timestamp || frameEnd)
+        perf.frameTimes.push(frameMs)
+        if (perf.frameTimes.length > PERF_OVERLAY.maxFrameSamples) perf.frameTimes.shift()
+        perf.frames++
+        perf.frameTimeMs = frameMs
+        if (frameEnd - perf.lastFpsUpdate >= PERF_OVERLAY.updateIntervalMs) {
+          perf.fps = perf.frames
+          perf.frames = 0
+          perf.lastFpsUpdate = frameEnd
+          const sorted = [...perf.frameTimes].sort((a, b) => a - b)
+          perf.p95 = sorted[Math.floor(sorted.length * 0.95)] || 0
+        }
+        const po = PERF_OVERLAY
+        const textX = po.x + po.padding
+        let textY = po.y + po.lineHeight + 2
+        ctx.save()
+        ctx.fillStyle = po.bgColor
+        ctx.fillRect(po.x, po.y, po.width, po.height)
+        ctx.font = po.font
+        ctx.fillStyle = perf.fps < po.fpsWarning ? po.fpsWarningColor : perf.fps < po.fpsCaution ? po.fpsCautionColor : po.fpsGoodColor
+        ctx.fillText(`FPS: ${perf.fps}`, textX, textY); textY += po.lineHeight
+        ctx.fillStyle = po.textColor
+        ctx.fillText(`Frame: ${frameMs.toFixed(1)}ms  P95: ${perf.p95.toFixed(1)}ms`, textX, textY); textY += po.lineHeight
+        ctx.fillText(`Agents: ${agents.size}`, textX, textY); textY += po.lineHeight
+        ctx.fillText(`Tool calls: ${toolCalls.size}`, textX, textY); textY += po.lineHeight
+        ctx.fillText(`Particles: ${particles.length}`, textX, textY); textY += po.lineHeight
+        ctx.fillText(`Edges: ${edges.length}`, textX, textY); textY += po.lineHeight
+        ctx.fillText(`Discoveries: ${discoveries.length}`, textX, textY)
+        ctx.restore()
+      }
 
-    ctx.restore()
-
-    if (showCostOverlay) drawCostSummaryPanel(ctx, agents, toolCalls)
-    if (bloomRef.current) bloomRef.current.apply(canvas, ctx)
     } catch (err) {
       // Log at most once every 5s to avoid flooding the console
       const now = Date.now()

--- a/web/components/agent-visualizer/control-bar.tsx
+++ b/web/components/agent-visualizer/control-bar.tsx
@@ -46,15 +46,21 @@ const EventMarkers = memo(function EventMarkers({ events, totalDuration, classNa
   events: TimelineEvent[]
   totalDuration: number
   className?: string
+  /** Pass events.length to bust memo when array is mutated in place */
+  eventCount?: number
 }) {
   // Down-sample to MAX_SCRUBBER_DOTS evenly spaced events when list is large
   const visible = events.length > MAX_SCRUBBER_DOTS
     ? Array.from({ length: MAX_SCRUBBER_DOTS }, (_, i) => events[Math.floor(i * events.length / MAX_SCRUBBER_DOTS)])
     : events
+  // Position dots relative to the last event so they always span the full bar,
+  // rather than compressing into a fraction when currentTime runs ahead of events
+  const lastEventTime = events.length > 0 ? events[events.length - 1].timestamp : 0
+  const effectiveDuration = lastEventTime > 0 ? lastEventTime : totalDuration
   return (
     <>
       {visible.map((event) => {
-        const pos = totalDuration > 0 ? (event.timestamp / totalDuration) * 100 : 0
+        const pos = effectiveDuration > 0 ? (event.timestamp / effectiveDuration) * 100 : 0
         if (pos < 0 || pos > 100) return null
         return (
           <div
@@ -131,7 +137,7 @@ function LiveControlBar({
             className="w-full rounded-full relative"
             style={{ height: 3, background: COLORS.holoBg10 }}
           >
-            <EventMarkers events={scrubberEvents} totalDuration={totalDuration} className="opacity-80" />
+            <EventMarkers events={scrubberEvents} totalDuration={totalDuration} eventCount={scrubberEvents.length} className="opacity-80" />
           </div>
         </div>
 
@@ -241,6 +247,7 @@ function ReviewControlBar({
             <EventMarkers
               events={scrubberEvents}
               totalDuration={totalDuration}
+              eventCount={scrubberEvents.length}
               className="opacity-60 group-hover:opacity-100 transition-opacity"
             />
           </div>

--- a/web/components/agent-visualizer/file-attention-panel.tsx
+++ b/web/components/agent-visualizer/file-attention-panel.tsx
@@ -13,6 +13,8 @@ interface FileAttentionPanelProps {
 }
 
 export function FileAttentionPanel({ visible, fileAttention, onClose, onOpenFile }: FileAttentionPanelProps) {
+  if (!visible) return null
+
   const files = Array.from(fileAttention.values())
     .sort((a, b) => b.totalTokens - a.totalTokens)
 
@@ -85,9 +87,13 @@ export function FileAttentionPanel({ visible, fileAttention, onClose, onOpenFile
                       {file.edits} edit{file.edits > 1 ? 's' : ''}
                     </span>
                   )}
-                  <span className="text-[9px] font-mono" style={{ color: COLORS.textMuted }}>
-                    {file.agents.join(', ')}
-                  </span>
+                  {file.agents.length > 0 && (
+                    <span className="text-[9px] font-mono" style={{ color: COLORS.textMuted }}
+                      title={file.agents.join(', ')}
+                    >
+                      {file.agents.length} agent{file.agents.length > 1 ? 's' : ''}
+                    </span>
+                  )}
                 </div>
               </div>
             )

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -29,6 +29,7 @@ export function AgentVisualizer() {
   const bridge = useVSCodeBridge()
 
   const {
+    frameRef,
     agents,
     toolCalls,
     particles,
@@ -117,24 +118,35 @@ export function AgentVisualizer() {
     }
   }, [bridge.selectedSessionId, restart, bridge.flushSessionEvents, saveSnapshot, restoreSnapshot, bridge.getSessionEventCount])
 
-  // Timeline events
-  const timelineEvents = useMemo((): TimelineEvent[] => {
-    const events: TimelineEvent[] = []
-    let eventIndex = 0
+  // Timeline events — incremental: only processes new conversation messages
+  const timelineCacheRef = useRef<{
+    counts: Map<string, number>
+    events: TimelineEvent[]
+    idCounter: number
+  }>({ counts: new Map(), events: [], idCounter: 0 })
 
-    for (const [agentId, convMessages] of conversations) {
-      for (const msg of convMessages) {
-        events.push({
-          id: `event-${eventIndex++}`,
-          type: msg.type === 'tool_call' ? 'tool_call' : msg.type === 'tool_result' ? 'tool_result' : 'message',
-          label: msg.content.slice(0, 20),
-          timestamp: msg.timestamp,
-          nodeId: agentId,
-        })
+  const timelineEvents = useMemo((): TimelineEvent[] => {
+    const cache = timelineCacheRef.current
+    let appended = false
+    for (const [agentId, msgs] of conversations) {
+      const prevLen = cache.counts.get(agentId) ?? 0
+      if (msgs.length > prevLen) {
+        for (let i = prevLen; i < msgs.length; i++) {
+          const msg = msgs[i]
+          cache.events.push({
+            id: `event-${cache.idCounter++}`,
+            type: msg.type === 'tool_call' ? 'tool_call' : msg.type === 'tool_result' ? 'tool_result' : 'message',
+            label: msg.content.slice(0, 20),
+            timestamp: msg.timestamp,
+            nodeId: agentId,
+          })
+        }
+        cache.counts.set(agentId, msgs.length)
+        appended = true
       }
     }
-
-    return events.sort((a, b) => a.timestamp - b.timestamp)
+    if (appended) cache.events.sort((a, b) => a.timestamp - b.timestamp)
+    return cache.events
   }, [conversations])
 
   // Review mode: when in live mode and user pauses to scrub through history
@@ -218,6 +230,17 @@ export function AgentVisualizer() {
     ]
   ) : []
 
+  const handleCloseSession = useCallback((id: string) => {
+    bridge.removeSession(id)
+    sessionCacheRef.current.delete(id)
+    if (bridge.selectedSessionId === id) {
+      const remaining = bridge.sessions.filter(s => s.id !== id)
+      if (remaining.length > 0) {
+        bridge.selectSession(remaining[remaining.length - 1].id)
+      }
+    }
+  }, [bridge])
+
   const openFile = useCallback((filePath: string, line?: number) => {
     bridge.bridgeOpenFile(filePath, line)
   }, [bridge])
@@ -227,11 +250,7 @@ export function AgentVisualizer() {
     <div className="h-screen w-screen relative overflow-hidden" style={{ background: COLORS.void }}>
       {/* Canvas fills everything */}
       <AgentCanvas
-        agents={agents}
-        toolCalls={toolCalls}
-        particles={particles}
-        edges={edges}
-        discoveries={discoveries}
+        simulationRef={frameRef}
         selectedAgentId={selection.selectedAgentId}
         hoveredAgentId={selection.hoveredAgentId}
         showStats={showStats}
@@ -246,7 +265,6 @@ export function AgentVisualizer() {
         selectedToolCallId={selection.selectedToolCallId}
         onDiscoveryClick={selection.handleDiscoveryClick}
         selectedDiscoveryId={selection.selectedDiscoveryId}
-        currentTime={currentTime}
         showCostOverlay={showCostOverlay}
       />
 
@@ -268,7 +286,7 @@ export function AgentVisualizer() {
         </div>
       )}
 
-      {/* Tool call detail popup (uses snapshot so it persists after card fades) */}
+      {/* Tool call detail popup */}
       {selection.selectedToolData && selection.selectedToolScreenPos && (
         <div {...stopPropagationHandlers}>
           <ToolDetailPopup
@@ -279,7 +297,7 @@ export function AgentVisualizer() {
         </div>
       )}
 
-      {/* Discovery detail popup (uses snapshot so it persists after card fades) */}
+      {/* Discovery detail popup */}
       {selection.selectedDiscoveryData && selection.selectedDiscoveryScreenPos && (
         <div {...stopPropagationHandlers}>
           <DiscoveryDetailPopup
@@ -313,7 +331,10 @@ export function AgentVisualizer() {
         isPlaying={isPlaying}
         speed={speed}
         currentTime={currentTime}
-        totalDuration={bridge.useMockData ? MOCK_DURATION : Math.max(maxTimeReached, currentTime)}
+        totalDuration={bridge.useMockData
+          ? (isReviewing ? Math.max(maxTimeReached, currentTime) : MOCK_DURATION)
+          : Math.max(maxTimeReached, currentTime)
+        }
         onPlayPause={handlePlayPause}
         onRestart={handleRestart}
         onSpeedChange={setSpeed}
@@ -360,20 +381,11 @@ export function AgentVisualizer() {
         sessions={bridge.sessions}
         selectedSessionId={bridge.selectedSessionId}
         sessionsWithActivity={bridge.sessionsWithActivity}
-        onSelectSession={(id) => bridge.selectSession(id)}
-        onCloseSession={(id) => {
-          bridge.removeSession(id)
-          sessionCacheRef.current.delete(id)
-          if (bridge.selectedSessionId === id) {
-            const remaining = bridge.sessions.filter(s => s.id !== id)
-            if (remaining.length > 0) {
-              bridge.selectSession(remaining[remaining.length - 1].id)
-            }
-          }
-        }}
+        onSelectSession={bridge.selectSession}
+        onCloseSession={handleCloseSession}
         isVSCode={bridge.isVSCode}
         connectionStatus={bridge.connectionStatus}
-        agents={agents}
+        agentCount={agents.size}
         totalTokens={totalTokens}
         showFileAttention={showFileAttention}
         showTranscript={showTranscript}

--- a/web/components/agent-visualizer/message-feed-panel.tsx
+++ b/web/components/agent-visualizer/message-feed-panel.tsx
@@ -5,6 +5,7 @@ import { Agent, Z, type AgentState } from '@/lib/agent-types'
 import { COLORS, ROLE_COLORS, getStateColor } from '@/lib/colors'
 import type { ConversationMessage } from '@/hooks/simulation/types'
 import { useClickOutside } from '@/hooks/use-click-outside'
+import { useVirtualList } from '@/hooks/use-virtual-list'
 
 interface MessageFeedPanelProps {
   conversations: Map<string, ConversationMessage[]>
@@ -21,7 +22,10 @@ const COLLAPSED_AGENT_NAME_MAX = 12
 const TAB_AGENT_NAME_MAX = 14
 const PREVIEW_MAX = 50
 const MESSAGE_TRUNCATE_MAX = 120
-const AUTO_SCROLL_THRESHOLD = 60
+
+const MESSAGE_GAP = 4
+
+// ─── Main component ─────────────────────────────────────────────────────────
 
 export function MessageFeedPanel({
   conversations,
@@ -38,15 +42,34 @@ export function MessageFeedPanel({
   agentsRef.current = agents
 
   // Stable key that only changes when agent set membership or names change
-  // (not on every position/opacity animation tick)
   const agentKey = useMemo(() => {
     const parts: string[] = []
     for (const [id, a] of agents) parts.push(`${id}:${a.name}:${a.isMain}`)
     return parts.sort().join('|')
   }, [agents])
 
-  // Agents that exist in the current session AND have text messages
+  // ── Latest message (cheap — used by collapsed view) ──
+  const latestMessage = useMemo(() => {
+    const currentAgents = agentsRef.current
+    let latest: (ConversationMessage & { agentId: string }) | null = null
+    for (const [agentId, msgs] of conversations) {
+      if (!currentAgents.has(agentId)) continue
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (!TEXT_TYPES.has(msgs[i].type)) continue
+        if (!latest || msgs[i].timestamp > latest.timestamp) {
+          latest = { ...msgs[i], agentId }
+        }
+        break
+      }
+    }
+    return latest
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversations, agentKey])
+
+  // ── Expensive memos — only compute when expanded ──
+
   const agentsWithMessages = useMemo(() => {
+    if (!expanded) return []
     const currentAgents = agentsRef.current
     const ids: string[] = []
     for (const [agentId, msgs] of conversations) {
@@ -60,50 +83,67 @@ export function MessageFeedPanel({
       if (agB?.isMain) return 1
       return (agA?.name ?? a).localeCompare(agB?.name ?? b)
     })
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- agentKey is a stable proxy for agents
-  }, [conversations, agentKey])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded ? conversations : null, expanded, agentKey])
 
-  // Text-only messages for the active tab
+  // Incremental message cache
+  const messagesCacheRef = useRef<{
+    key: string
+    counts: Map<string, number>
+    result: (ConversationMessage & { agentId: string })[]
+  }>({ key: '', counts: new Map(), result: [] })
+
   const messages = useMemo(() => {
+    if (!expanded) return []
     const currentAgents = agentsRef.current
+    const cache = messagesCacheRef.current
+    const cacheKey = `${activeTab}:${agentKey}`
+
+    if (cache.key !== cacheKey) {
+      cache.key = cacheKey
+      cache.counts = new Map()
+      cache.result = []
+    }
+
     if (activeTab === 'all') {
-      const all: (ConversationMessage & { agentId: string })[] = []
+      let appended = false
       for (const [agentId, msgs] of conversations) {
         if (!currentAgents.has(agentId)) continue
-        for (const msg of msgs) {
-          if (TEXT_TYPES.has(msg.type)) all.push({ ...msg, agentId })
+        const prevLen = cache.counts.get(agentId) ?? 0
+        if (msgs.length > prevLen) {
+          for (let i = prevLen; i < msgs.length; i++) {
+            if (TEXT_TYPES.has(msgs[i].type)) cache.result.push({ ...msgs[i], agentId })
+          }
+          cache.counts.set(agentId, msgs.length)
+          appended = true
         }
       }
-      return all.sort((a, b) => a.timestamp - b.timestamp)
+      if (appended) cache.result.sort((a, b) => a.timestamp - b.timestamp)
+      return cache.result
     }
-    return (conversations.get(activeTab) ?? [])
-      .filter(m => TEXT_TYPES.has(m.type))
-      .map(msg => ({ ...msg, agentId: activeTab }))
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- agentKey is a stable proxy for agents
-  }, [conversations, activeTab, agentKey])
 
-  // Latest text message (for collapsed view)
-  const latestMessage = useMemo(() => {
-    const currentAgents = agentsRef.current
-    let latest: (ConversationMessage & { agentId: string }) | null = null
-    for (const [agentId, msgs] of conversations) {
-      if (!currentAgents.has(agentId)) continue
-      for (const msg of msgs) {
-        if (!TEXT_TYPES.has(msg.type)) continue
-        if (!latest || msg.timestamp > latest.timestamp) {
-          latest = { ...msg, agentId }
-        }
+    const msgs = conversations.get(activeTab) ?? []
+    const prevLen = cache.counts.get(activeTab) ?? 0
+    if (msgs.length > prevLen) {
+      for (let i = prevLen; i < msgs.length; i++) {
+        if (TEXT_TYPES.has(msgs[i].type)) cache.result.push({ ...msgs[i], agentId: activeTab })
       }
+      cache.counts.set(activeTab, msgs.length)
     }
-    return latest
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- agentKey is a stable proxy for agents
-  }, [conversations, agentKey])
+    return cache.result
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded ? conversations : null, expanded, activeTab, agentKey])
+
+  // Virtual list with auto-scroll
+  const {
+    visibleItems, totalHeight, offsetTop,
+    handleScroll, measureRef,
+  } = useVirtualList(messages, logRef, { gap: MESSAGE_GAP, autoScroll: true })
 
   // Track unread messages per agent tab
   useEffect(() => {
     const totalCount = Array.from(conversations.values()).reduce((n, msgs) => n + msgs.length, 0)
     if (totalCount > prevCountRef.current && expanded) {
-      // Find which agents got new messages
       for (const [agentId, msgs] of conversations) {
         if (agentId !== activeTab && activeTab !== 'all' && msgs.length > 0) {
           setUnread(prev => new Set(prev).add(agentId))
@@ -113,67 +153,33 @@ export function MessageFeedPanel({
     prevCountRef.current = totalCount
   }, [conversations, expanded, activeTab])
 
-  // Clear unread when switching tabs
   useEffect(() => {
     if (activeTab !== 'all') {
-      setUnread(prev => {
-        const next = new Set(prev)
-        next.delete(activeTab)
-        return next
-      })
+      setUnread(prev => { const next = new Set(prev); next.delete(activeTab); return next })
     } else {
       setUnread(new Set())
     }
   }, [activeTab])
 
-  // Reset tab when the active agent no longer exists (e.g. session switch)
   useEffect(() => {
-    if (activeTab !== 'all' && !conversations.has(activeTab)) {
-      setActiveTab('all')
-    }
+    if (activeTab !== 'all' && !conversations.has(activeTab)) setActiveTab('all')
   }, [conversations, activeTab])
 
-  // Auto-switch tab when an agent is selected
   useEffect(() => {
     if (selectedAgentId) {
       const selected = agentsRef.current.get(selectedAgentId)
-      if (selected && !selected.isMain) {
-        // Focus on the subagent's tab (don't auto-expand — may overlap detail card)
-        setActiveTab(selectedAgentId)
-      } else {
-        setActiveTab('all')
-      }
+      if (selected && !selected.isMain) setActiveTab(selectedAgentId)
+      else setActiveTab('all')
     } else {
       setActiveTab('all')
     }
   }, [selectedAgentId])
 
-  // Auto-scroll on new messages
-  useEffect(() => {
-    if (expanded && logRef.current) {
-      const el = logRef.current
-      const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < AUTO_SCROLL_THRESHOLD
-      if (nearBottom) {
-        el.scrollTop = el.scrollHeight
-      }
-    }
-  }, [messages.length, expanded])
-
-  // Scroll to bottom when first expanded
-  const prevExpandedRef = useRef(false)
-  useEffect(() => {
-    if (expanded && !prevExpandedRef.current && logRef.current) {
-      logRef.current.scrollTop = logRef.current.scrollHeight
-    }
-    prevExpandedRef.current = expanded
-  }, [expanded])
-
-  // Click outside to collapse
   const panelRef = useRef<HTMLDivElement>(null)
   const collapsePanel = useCallback(() => setExpanded(false), [])
   useClickOutside(panelRef, collapsePanel)
 
-  if (agentsWithMessages.length === 0 && !latestMessage) return null
+  if (!latestMessage && agentsWithMessages.length === 0) return null
 
   // ── Collapsed ──
   if (!expanded) {
@@ -190,28 +196,20 @@ export function MessageFeedPanel({
         onClick={() => setExpanded(true)}
       >
         <div className="glass-card px-3 py-2 flex items-center gap-2" style={{ maxWidth: 320 }}>
-          <div
-            className="w-1.5 h-1.5 rounded-full shrink-0"
-            style={{ background: role.text }}
-          />
+          <div className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: role.text }} />
           <span className="text-[9px] font-mono font-semibold shrink-0" style={{ color: COLORS.textPrimary }}>
             {agentName.length > COLLAPSED_AGENT_NAME_MAX ? agentName.slice(0, COLLAPSED_AGENT_NAME_MAX) + '..' : agentName}
           </span>
-          <span
-            className="text-[9px] font-mono truncate"
-            style={{ color: role.text + 'cc' }}
-          >
+          <span className="text-[9px] font-mono truncate" style={{ color: role.text + 'cc' }}>
             {preview}{latestMessage.content.length > PREVIEW_MAX ? '...' : ''}
           </span>
-          <span className="text-[9px] shrink-0" style={{ color: COLORS.textMuted }}>
-            ▾
-          </span>
+          <span className="text-[9px] shrink-0" style={{ color: COLORS.textMuted }}>▾</span>
         </div>
       </div>
     )
   }
 
-  // ── Expanded ──
+  // ── Expanded (virtualized) ──
   return (
     <div
       ref={panelRef}
@@ -261,10 +259,11 @@ export function MessageFeedPanel({
         </div>
         )}
 
-        {/* Message List */}
+        {/* Message List (virtualized) */}
         <div
           ref={logRef}
-          className="flex-1 overflow-y-auto px-2 pb-2 space-y-1"
+          onScroll={handleScroll}
+          className="flex-1 overflow-y-auto px-2 pb-2"
           style={{ maxHeight: 340, scrollbarWidth: 'thin', scrollbarColor: `${COLORS.scrollbarThumb} transparent` }}
         >
           {messages.length === 0 ? (
@@ -274,17 +273,26 @@ export function MessageFeedPanel({
               </span>
             </div>
           ) : (
-            messages.map((msg) => (
-              <MessageRow
-                key={msg.id}
-                message={msg}
-                agentId={msg.agentId}
-                agentName={agents.get(msg.agentId)?.name ?? msg.agentId}
-                showAgent={activeTab === 'all'}
-                isSelected={selectedAgentId === msg.agentId}
-                onClick={() => { onAgentClick(msg.agentId); setExpanded(false) }}
-              />
-            ))
+            <div style={{ height: totalHeight, position: 'relative' }}>
+              <div style={{ position: 'absolute', top: offsetTop, left: 0, right: 0 }}>
+                {visibleItems.map((msg) => (
+                  <div
+                    key={msg.id}
+                    ref={(el) => measureRef(msg.id, el)}
+                    style={{ marginBottom: MESSAGE_GAP }}
+                  >
+                    <MessageRow
+                      message={msg}
+                      agentId={msg.agentId}
+                      agentName={agents.get(msg.agentId)?.name ?? msg.agentId}
+                      showAgent={activeTab === 'all'}
+                      isSelected={selectedAgentId === msg.agentId}
+                      onClick={() => { onAgentClick(msg.agentId); setExpanded(false) }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/web/components/agent-visualizer/session-transcript-panel.tsx
+++ b/web/components/agent-visualizer/session-transcript-panel.tsx
@@ -6,9 +6,14 @@ import { COLORS } from '@/lib/colors'
 import { TranscriptMessage } from './transcript-message'
 import type { ConversationMessage } from '@/hooks/simulation/types'
 import { CloseButton, SlidingPanel, stopPropagationHandlers } from './shared-ui'
-import { useAutoScroll } from '@/hooks/use-auto-scroll'
+import { useVirtualList } from '@/hooks/use-virtual-list'
 
-// ─── Full session transcript panel ───────────────────────────────────────────
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const TRANSCRIPT_GAP = 8 // matches mb-2
+const TRANSCRIPT_INITIAL_VIEWPORT = 400
+
+// ─── Component ──────────────────────────────────────────────────────────────
 
 interface TranscriptPanelProps {
   visible: boolean
@@ -24,20 +29,33 @@ export function SessionTranscriptPanel({
   const [searchQuery, setSearchQuery] = useState('')
   const [showSearch, setShowSearch] = useState(false)
   const searchRef = useRef<HTMLInputElement>(null)
-  const { ref: logRef, handleScroll, scrollToBottom, isAutoScrolling } = useAutoScroll(conversation.length, visible)
+  const scrollRef = useRef<HTMLDivElement>(null)
 
-  // Focus search when shown
   useEffect(() => {
     if (showSearch) searchRef.current?.focus()
   }, [showSearch])
 
-  const filteredConversation = searchQuery.trim()
-    ? conversation.filter(msg => {
-        const q = searchQuery.toLowerCase()
-        return msg.content.toLowerCase().includes(q)
-          || (msg.toolName || '').toLowerCase().includes(q)
-      })
-    : conversation
+  const filteredConversation = visible
+    ? (searchQuery.trim()
+        ? conversation.filter(msg => {
+            const q = searchQuery.toLowerCase()
+            return msg.content.toLowerCase().includes(q)
+              || (msg.toolName || '').toLowerCase().includes(q)
+          })
+        : conversation)
+    : []
+
+  const {
+    visibleItems, totalHeight, offsetTop,
+    handleScroll, measureRef: itemMeasureRef,
+    isAtBottom, scrollToBottom,
+  } = useVirtualList(filteredConversation, scrollRef, {
+    gap: TRANSCRIPT_GAP,
+    initialViewportHeight: TRANSCRIPT_INITIAL_VIEWPORT,
+    autoScroll: true,
+  })
+
+  if (!visible) return null
 
   return (
     <SlidingPanel
@@ -106,11 +124,11 @@ export function SessionTranscriptPanel({
           </div>
         )}
 
-        {/* Messages */}
+        {/* Virtualized message list */}
         <div
-          ref={logRef}
+          ref={scrollRef}
           onScroll={handleScroll}
-          className="flex-1 overflow-y-auto px-3 py-2 space-y-2"
+          className="flex-1 overflow-y-auto px-3 py-2"
           style={{ scrollbarWidth: 'thin', scrollbarColor: `${COLORS.scrollbarThumb} transparent` }}
         >
           {filteredConversation.length === 0 ? (
@@ -120,29 +138,38 @@ export function SessionTranscriptPanel({
               </p>
             </div>
           ) : (
-            filteredConversation.map((msg) => (
-              <TranscriptMessage key={msg.id} message={msg} searchQuery={searchQuery} />
-            ))
-          )}
-
-          {/* Scroll-to-bottom indicator */}
-          {!isAutoScrolling.current && filteredConversation.length > 0 && (
-            <div className="sticky bottom-0 flex justify-center py-1">
-              <button
-                onClick={scrollToBottom}
-                className="text-[9px] font-mono px-3 py-1 rounded-full transition-all"
-                style={{
-                  background: COLORS.holoBg10,
-                  border: `1px solid ${COLORS.glassBorder}`,
-                  color: COLORS.scrollBtnText,
-                }}
-              >
-                ↓ New messages
-              </button>
+            <div style={{ height: totalHeight, position: 'relative' }}>
+              <div style={{ position: 'absolute', top: offsetTop, left: 0, right: 0 }}>
+                {visibleItems.map((msg) => (
+                  <div
+                    key={msg.id}
+                    ref={(el) => itemMeasureRef(msg.id, el)}
+                    style={{ marginBottom: TRANSCRIPT_GAP }}
+                  >
+                    <TranscriptMessage message={msg} searchQuery={searchQuery} />
+                  </div>
+                ))}
+              </div>
             </div>
           )}
         </div>
 
+        {/* Scroll-to-bottom button */}
+        {!isAtBottom && filteredConversation.length > 0 && (
+          <div className="flex justify-center py-1 flex-shrink-0" style={{ borderTop: `1px solid ${COLORS.holoBorder06}` }}>
+            <button
+              onClick={scrollToBottom}
+              className="text-[9px] font-mono px-3 py-1 rounded-full transition-all"
+              style={{
+                background: COLORS.holoBg10,
+                border: `1px solid ${COLORS.glassBorder}`,
+                color: COLORS.scrollBtnText,
+              }}
+            >
+              ↓ New messages
+            </button>
+          </div>
+        )}
       </div>
     </SlidingPanel>
   )

--- a/web/components/agent-visualizer/timeline-panel.tsx
+++ b/web/components/agent-visualizer/timeline-panel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRef, useEffect, useMemo } from 'react'
 import { TimelineEntry, Z } from '@/lib/agent-types'
 import { COLORS } from '@/lib/colors'
 import { PanelHeader, SlidingPanel } from './shared-ui'
@@ -11,12 +12,48 @@ interface TimelinePanelProps {
   onClose: () => void
 }
 
-export function TimelinePanel({ visible, timelineEntries, currentTime, onClose }: TimelinePanelProps) {
-  const entries = Array.from(timelineEntries.values())
-    .sort((a, b) => a.startTime - b.startTime)
+// ─── Layout constants ────────────────────────────────────────────────────────
 
-  // Compute time range (avoid spread on large arrays to prevent stack overflow)
-  let minTime = entries.length > 0 ? entries[0].startTime : 0
+const ROW_HEIGHT = 22
+const HEADER_HEIGHT = 20
+const LABEL_WIDTH = 90
+const FONT = '9px monospace'
+
+// ─── Legend (static DOM — no perf cost) ─────────────────────────────────────
+
+const LEGEND_ITEMS = [
+  { color: COLORS.idle, label: 'Idle' },
+  { color: COLORS.thinking, label: 'Thinking' },
+  { color: COLORS.tool, label: 'Tool Call' },
+  { color: COLORS.error, label: 'Error' },
+  { color: COLORS.complete, label: 'Complete' },
+]
+
+// ─── Canvas-based timeline rendering ────────────────────────────────────────
+
+function drawTimeline(
+  ctx: CanvasRenderingContext2D,
+  entries: TimelineEntry[],
+  currentTime: number,
+  width: number,
+  height: number,
+  dpr: number,
+) {
+  ctx.clearRect(0, 0, width * dpr, height * dpr)
+  ctx.save()
+  ctx.scale(dpr, dpr)
+
+  if (entries.length === 0) {
+    ctx.font = FONT
+    ctx.fillStyle = COLORS.textMuted
+    ctx.textAlign = 'center'
+    ctx.fillText('No timeline data', width / 2, height / 2)
+    ctx.restore()
+    return
+  }
+
+  // Compute time range
+  let minTime = entries[0].startTime
   let maxTime = currentTime
   for (const e of entries) {
     if (e.startTime < minTime) minTime = e.startTime
@@ -24,23 +61,133 @@ export function TimelinePanel({ visible, timelineEntries, currentTime, onClose }
     if (end > maxTime) maxTime = end
   }
   const timeSpan = Math.max(maxTime - minTime, 1)
-
-  const rowHeight = 22
-  const headerHeight = 20
-  const labelWidth = 90
-  const barAreaWidth = 400 // will scale to fit
+  const barWidth = width - LABEL_WIDTH
 
   // Time markers
-  const markerInterval = timeSpan > 20 ? 5 : timeSpan > 10 ? 2 : 1
+  const markerInterval = timeSpan > 60 ? 10 : timeSpan > 20 ? 5 : timeSpan > 10 ? 2 : 1
   const markers: number[] = []
   for (let t = Math.ceil(minTime / markerInterval) * markerInterval; t <= maxTime; t += markerInterval) {
     markers.push(t)
   }
 
+  ctx.font = FONT
+
+  // ── Header row: time labels ──
+  ctx.textAlign = 'center'
+  ctx.fillStyle = COLORS.textMuted
+  for (const t of markers) {
+    const x = LABEL_WIDTH + ((t - minTime) / timeSpan) * barWidth
+    ctx.fillText(`${t.toFixed(0)}s`, x, HEADER_HEIGHT - 4)
+  }
+
+  // ── Agent rows ──
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]
+    const y = HEADER_HEIGHT + i * ROW_HEIGHT
+
+    // Agent label
+    ctx.textAlign = 'right'
+    ctx.fillStyle = COLORS.textDim
+    const name = entry.agentName.length > 12 ? entry.agentName.slice(0, 12) + '..' : entry.agentName
+    ctx.fillText(name, LABEL_WIDTH - 6, y + ROW_HEIGHT / 2 + 3)
+
+    // Background track
+    const trackY = y + 4
+    const trackH = ROW_HEIGHT - 8
+    ctx.fillStyle = COLORS.holoBg03
+    ctx.fillRect(LABEL_WIDTH, trackY, barWidth, trackH)
+
+    // Vertical marker lines
+    ctx.fillStyle = COLORS.panelSeparator
+    for (const t of markers) {
+      const x = LABEL_WIDTH + ((t - minTime) / timeSpan) * barWidth
+      ctx.fillRect(x, trackY, 1, trackH)
+    }
+
+    // Blocks
+    for (const block of entry.blocks) {
+      const blockStart = ((block.startTime - minTime) / timeSpan) * barWidth
+      const blockEndTime = block.endTime ?? currentTime
+      const blockEnd = ((blockEndTime - minTime) / timeSpan) * barWidth
+      const blockW = Math.max(blockEnd - blockStart, 1)
+      const x = LABEL_WIDTH + blockStart
+
+      // Block fill
+      ctx.globalAlpha = 0.3
+      ctx.fillStyle = block.color
+      ctx.fillRect(x, trackY + 1, blockW, trackH - 2)
+
+      // Block border
+      ctx.globalAlpha = 0.2
+      ctx.strokeStyle = block.color
+      ctx.lineWidth = 1
+      ctx.strokeRect(x, trackY + 1, blockW, trackH - 2)
+
+      ctx.globalAlpha = 1
+
+      // Label inside block if wide enough
+      if (blockW > 40) {
+        ctx.save()
+        ctx.beginPath()
+        ctx.rect(x, trackY, blockW, trackH)
+        ctx.clip()
+        ctx.fillStyle = block.color
+        ctx.globalAlpha = 0.8
+        ctx.textAlign = 'left'
+        ctx.fillText(block.label, x + 4, trackY + trackH / 2 + 3)
+        ctx.restore()
+      }
+    }
+
+    // Playhead
+    const playheadX = LABEL_WIDTH + ((currentTime - minTime) / timeSpan) * barWidth
+    ctx.fillStyle = COLORS.holoHot
+    ctx.globalAlpha = 0.5
+    ctx.fillRect(playheadX, trackY, 1, trackH)
+    ctx.globalAlpha = 1
+  }
+
+  ctx.restore()
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function TimelinePanel({ visible, timelineEntries, currentTime, onClose }: TimelinePanelProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  const sortedEntries = useMemo(() => {
+    if (!visible) return []
+    return Array.from(timelineEntries.values()).sort((a, b) => a.startTime - b.startTime)
+  }, [visible, timelineEntries])
+
+  const canvasHeight = HEADER_HEIGHT + sortedEntries.length * ROW_HEIGHT
+
+  useEffect(() => {
+    if (!visible) return
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    // Use the scroll container's clientWidth (excludes scrollbar) for a snug fit
+    const scrollContainer = canvas.parentElement
+    const width = scrollContainer?.clientWidth ?? canvas.clientWidth
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = width * dpr
+    canvas.height = canvasHeight * dpr
+    canvas.style.width = `${width}px`
+    canvas.style.height = `${canvasHeight}px`
+
+    drawTimeline(ctx, sortedEntries, currentTime, width, canvasHeight, dpr)
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- redraw on every prop change (component only re-renders on data/time updates)
+  }, [visible, sortedEntries, currentTime, canvasHeight])
+
+  if (!visible) return null
+
   return (
     <SlidingPanel
       visible={visible}
-      position={{ bottom: 64, left: 16, right: 16 }}
+      position={{ bottom: 72, left: 16, right: 16 }}
       axis="Y"
       zIndex={Z.sidePanel}
       className="mx-auto"
@@ -53,133 +200,20 @@ export function TimelinePanel({ visible, timelineEntries, currentTime, onClose }
           </span>
         </PanelHeader>
 
-        <div className="overflow-x-auto">
-          <div style={{ minWidth: labelWidth + barAreaWidth }}>
-            {/* Time markers header */}
-            <div className="flex" style={{ height: headerHeight }}>
-              <div style={{ width: labelWidth, flexShrink: 0 }} />
-              <div className="flex-1 relative">
-                {markers.map(t => {
-                  const left = ((t - minTime) / timeSpan) * 100
-                  return (
-                    <div
-                      key={t}
-                      className="absolute text-[9px] font-mono"
-                      style={{
-                        left: `${left}%`,
-                        top: 4,
-                        transform: 'translateX(-50%)',
-                        color: COLORS.textMuted,
-                      }}
-                    >
-                      {t.toFixed(0)}s
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
+        <div className="overflow-auto" style={{ maxHeight: 300 }}>
+          <canvas ref={canvasRef} style={{ display: 'block' }} />
+        </div>
 
-            {/* Agent rows */}
-            {entries.map((entry) => (
-              <div key={entry.id} className="flex items-center" style={{ height: rowHeight }}>
-                {/* Agent label */}
-                <div
-                  className="text-[9px] font-mono truncate pr-2"
-                  style={{ width: labelWidth, flexShrink: 0, color: COLORS.textDim, textAlign: 'right' }}
-                >
-                  {entry.agentName}
-                </div>
-
-                {/* Blocks bar */}
-                <div className="flex-1 relative" style={{ height: 14 }}>
-                  {/* Background track */}
-                  <div
-                    className="absolute inset-0 rounded-sm"
-                    style={{ background: COLORS.holoBg03 }}
-                  />
-
-                  {/* Time markers (vertical lines) */}
-                  {markers.map(t => {
-                    const left = ((t - minTime) / timeSpan) * 100
-                    return (
-                      <div
-                        key={t}
-                        className="absolute top-0 bottom-0"
-                        style={{
-                          left: `${left}%`,
-                          width: 1,
-                          background: COLORS.panelSeparator,
-                        }}
-                      />
-                    )
-                  })}
-
-                  {/* Blocks */}
-                  {entry.blocks.map((block) => {
-                    const blockStart = ((block.startTime - minTime) / timeSpan) * 100
-                    const blockEnd = block.endTime
-                      ? ((block.endTime - minTime) / timeSpan) * 100
-                      : ((currentTime - minTime) / timeSpan) * 100
-                    const blockWidth = Math.max(blockEnd - blockStart, 0.5)
-
-                    return (
-                      <div
-                        key={block.id}
-                        className="absolute top-0.5 bottom-0.5 rounded-sm"
-                        style={{
-                          left: `${blockStart}%`,
-                          width: `${blockWidth}%`,
-                          background: block.color + '50',
-                          border: `1px solid ${block.color}30`,
-                          overflow: 'hidden',
-                        }}
-                        title={block.label}
-                      >
-                        {/* Label inside block if wide enough */}
-                        {blockWidth > 5 && (
-                          <span
-                            className="absolute inset-0 flex items-center px-1 text-[9px] font-mono truncate"
-                            style={{ color: block.color + 'cc' }}
-                          >
-                            {block.label}
-                          </span>
-                        )}
-                      </div>
-                    )
-                  })}
-
-                  {/* Current time playhead */}
-                  <div
-                    className="absolute top-0 bottom-0"
-                    style={{
-                      left: `${((currentTime - minTime) / timeSpan) * 100}%`,
-                      width: 1,
-                      background: COLORS.holoHot,
-                      opacity: 0.5,
-                    }}
-                  />
-                </div>
+        {/* Legend (static DOM) */}
+        <div className="flex items-center gap-3 px-3 py-1.5" style={{ borderTop: `1px solid ${COLORS.holoBorder06}` }}>
+          <div style={{ width: LABEL_WIDTH, flexShrink: 0 }} />
+          <div className="flex items-center gap-3">
+            {LEGEND_ITEMS.map(item => (
+              <div key={item.label} className="flex items-center gap-1">
+                <div className="w-2 h-2 rounded-sm" style={{ background: item.color + '70' }} />
+                <span className="text-[9px] font-mono" style={{ color: COLORS.textMuted }}>{item.label}</span>
               </div>
             ))}
-
-            {/* Legend */}
-            <div className="flex items-center gap-3 mt-2 pt-1" style={{ borderTop: `1px solid ${COLORS.holoBorder06}` }}>
-              <div style={{ width: labelWidth, flexShrink: 0 }} />
-              <div className="flex items-center gap-3">
-                {[
-                  { color: COLORS.idle, label: 'Idle' },
-                  { color: COLORS.thinking, label: 'Thinking' },
-                  { color: COLORS.tool, label: 'Tool Call' },
-                  { color: COLORS.error, label: 'Error' },
-                  { color: COLORS.complete, label: 'Complete' },
-                ].map(item => (
-                  <div key={item.label} className="flex items-center gap-1">
-                    <div className="w-2 h-2 rounded-sm" style={{ background: item.color + '70' }} />
-                    <span className="text-[9px] font-mono" style={{ color: COLORS.textMuted }}>{item.label}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { Agent, Z } from "@/lib/agent-types"
+import { memo } from "react"
+import { Z } from "@/lib/agent-types"
 import { COLORS } from "@/lib/colors"
 import { formatTokens } from "@/lib/utils"
 import { agentCost } from "./canvas/draw-cost"
@@ -86,7 +87,7 @@ export interface TopBarProps {
   isVSCode: boolean
   connectionStatus: ConnectionStatus
   // Stats
-  agents: Map<string, Agent>
+  agentCount: number
   totalTokens: number
   // Panel toggles
   showFileAttention: boolean
@@ -99,11 +100,11 @@ export interface TopBarProps {
   onToggleMute: () => void
 }
 
-export function TopBar({
+export const TopBar = memo(function TopBar({
   sessions, selectedSessionId, sessionsWithActivity,
   onSelectSession, onCloseSession,
   isVSCode, connectionStatus,
-  agents, totalTokens,
+  agentCount, totalTokens,
   showFileAttention, showTranscript, showCostOverlay, showTimeline, isMuted,
   onTogglePanel, onToggleTimeline, onToggleMute,
 }: TopBarProps) {
@@ -128,7 +129,7 @@ export function TopBar({
       {/* Right-side info/controls */}
       <div className="flex items-center gap-4 flex-shrink-0" style={{ color: COLORS.textMuted }}>
         {isVSCode && <ConnectionIndicator status={connectionStatus} />}
-        <span>{agents.size} agents</span>
+        <span>{agentCount} agents</span>
         <span>
           {formatTokens(totalTokens)} tokens
           <span style={{ color: COLORS.complete + '65', marginLeft: 4 }}>
@@ -161,4 +162,4 @@ export function TopBar({
       </div>
     </div>
   )
-}
+})

--- a/web/hooks/simulation/animate.ts
+++ b/web/hooks/simulation/animate.ts
@@ -102,13 +102,10 @@ function cleanupFaded(
     filteredEdges = filteredEdges.filter(e => !fadedSet.has(e.from) && !fadedSet.has(e.to))
   }
 
-  // Cleanup faded tool calls and their edges
+  // Cleanup faded tool calls (opacity <= 0) and their edges
   const fadedToolIds: string[] = []
-  for (const e of filteredEdges) {
-    if (e.type === 'tool') {
-      const tc = newToolCalls.get(e.to)
-      if (tc && tc.opacity <= 0) fadedToolIds.push(e.to)
-    }
+  for (const [id, tc] of newToolCalls) {
+    if (tc.opacity <= 0) fadedToolIds.push(id)
   }
   if (fadedToolIds.length > 0) {
     if (newToolCalls === originalToolCalls) newToolCalls = new Map(originalToolCalls)

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -18,27 +18,39 @@ import { processEvent, type ProcessEventContext } from './simulation/process-eve
 import { computeNextFrame } from './simulation/animate'
 import { snapVisualState } from './simulation/snap-visual-state'
 
+/** ms between React state updates — canvas uses frameRef for smooth 60fps */
+const UI_THROTTLE_MS = 250
+
 export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
   const { useMockData = true, externalEvents, onExternalEventsConsumed, sessionFilter, sessionFilterRef: externalFilterRef } = options
-  // Ref so the animation frame always reads the current sessionFilter,
-  // not a stale closure value from when animate was last recreated.
   const internalFilterRef = useRef(sessionFilter)
   internalFilterRef.current = sessionFilter
-  // Use the external ref if provided (updated synchronously in event handlers),
-  // otherwise fall back to the internal ref (updated during render).
   const sessionFilterRef = externalFilterRef ?? internalFilterRef
+
+  // ─── State management ──────────────────────────────────────────────────────
+  // frameRef: source of truth, updated every animation frame (no React render).
+  // state: React state for UI components, updated only on structural data changes
+  //        (new events, play/pause, seek) — NOT on every animation tick.
+  // Canvas reads from frameRef directly for 60fps rendering.
   const [state, setState] = useState<SimulationState>(createEmptyState)
+  const frameRef = useRef<SimulationState>(createEmptyState())
+
+  /** Update both frameRef and React state (triggers UI re-render) */
+  const commitState = useCallback((next: SimulationState) => {
+    frameRef.current = next
+    setState(next)
+  }, [])
+
   const animationRef = useRef<number>(0)
   const lastTimeRef = useRef<number>(0)
   const forceSimRef = useRef<Simulation<ForceNode, ForceLink> | null>(null)
   const blockIdCounter = useRef(0)
-  /** When true, processEvent skips force sim sync (during seek replay) */
   const skipForceSyncRef = useRef(false)
-  // Stable ref to animate — lets the useEffect/rAF loop always call the latest
-  // version without depending on animate's identity (which changes with props).
   const animateRef = useRef<(timestamp: number) => void>(() => {})
+  /** Throttle React UI updates to ~4/sec — canvas stays smooth via frameRef */
+  const lastUIUpdateRef = useRef(0)
 
-  // Initialize d3-force simulation
+  // ─── d3-force simulation ─────────────────────────────────────────────────
   useEffect(() => {
     const sim = forceSimulation<ForceNode, ForceLink>([])
       .force('charge', forceManyBody().strength(FORCE.chargeStrength))
@@ -48,31 +60,30 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
       .alphaDecay(FORCE.alphaDecay)
       .velocityDecay(FORCE.velocityDecay)
       .on('tick', () => {
-        setState(prev => {
-          const newAgents = new Map(prev.agents)
-          let changed = false
-          for (const node of sim.nodes()) {
-            const agent = newAgents.get(node.id)
-            if (agent && !agent.pinned && node.x !== undefined && node.y !== undefined) {
-              if (Math.abs(agent.x - node.x) > 0.1 || Math.abs(agent.y - node.y) > 0.1) {
-                newAgents.set(node.id, { ...agent, x: node.x, y: node.y })
-                changed = true
-              }
+        // Force tick only updates positions — write to frameRef, no React render
+        const prev = frameRef.current
+        const newAgents = new Map(prev.agents)
+        let changed = false
+        for (const node of sim.nodes()) {
+          const agent = newAgents.get(node.id)
+          if (agent && !agent.pinned && node.x !== undefined && node.y !== undefined) {
+            if (Math.abs(agent.x - node.x) > 0.1 || Math.abs(agent.y - node.y) > 0.1) {
+              newAgents.set(node.id, { ...agent, x: node.x, y: node.y })
+              changed = true
             }
           }
-          return changed ? { ...prev, agents: newAgents } : prev
-        })
+        }
+        if (changed) {
+          frameRef.current = { ...prev, agents: newAgents }
+        }
       })
 
     sim.stop()
     forceSimRef.current = sim
-
-    return () => {
-      sim.stop()
-      forceSimRef.current = null
-    }
+    return () => { sim.stop(); forceSimRef.current = null }
   }, [])
 
+  // ─── Force simulation sync ───────────────────────────────────────────────
   const syncForceSimulation = useCallback((agents: Map<string, Agent>, edges: Edge[]) => {
     const sim = forceSimRef.current
     if (!sim) return
@@ -97,7 +108,7 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     sim.stop()
   }, [])
 
-  // Find a clear slot for a tool card, spawning outward from the agent (away from parent)
+  // ─── Tool slot placement ─────────────────────────────────────────────────
   const findToolSlot = useCallback((
     agent: Agent, agents: Map<string, Agent>,
     toolCalls: Map<string, ToolCallNode>, currentTime: number,
@@ -117,8 +128,7 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
       return false
     }
 
-    // Compute outward direction: away from parent (or default upward for main agent)
-    let outAngle = -Math.PI / 2 // default: upward
+    let outAngle = -Math.PI / 2
     if (agent.parentId) {
       const parent = agents.get(agent.parentId)
       if (parent) {
@@ -126,12 +136,11 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
       }
     }
 
-    // Arc centered on outward direction, sweeping ±90°
     for (let ring = 1; ring <= TOOL_SLOT.maxRings; ring++) {
       const dist = TOOL_SLOT.baseDistance + ring * TOOL_SLOT.ringIncrement
       const steps = TOOL_SLOT.baseSteps + ring * TOOL_SLOT.stepsPerRing
       for (let i = 0; i < steps; i++) {
-        const sweep = (i / (steps - 1) - 0.5) * Math.PI // -90° to +90° around outAngle
+        const sweep = (i / (steps - 1) - 0.5) * Math.PI
         const angle = outAngle + sweep
         const cx = agent.x + Math.cos(angle) * dist
         const cy = agent.y + Math.sin(angle) * dist
@@ -161,103 +170,107 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     return processEvent(event, prev, ctx)
   }, [syncForceSimulation, findToolSlot, getContextWindowSize])
 
+  // ─── Animation loop ──────────────────────────────────────────────────────
+  // Reads/writes frameRef directly. Only calls commitState when new events
+  // are processed, so React only re-renders UI on structural data changes.
   const animate = useCallback((timestamp: number) => {
+    // Cap at 60fps to reduce CPU/GPU load
+    const elapsed = timestamp - lastTimeRef.current
+    if (lastTimeRef.current && elapsed < ANIM_SPEED.minFrameInterval) {
+      animationRef.current = requestAnimationFrame(animateRef.current)
+      return
+    }
+
     if (!lastTimeRef.current) lastTimeRef.current = timestamp
     const deltaTime = Math.min((timestamp - lastTimeRef.current) / 1000, ANIM_SPEED.maxDeltaTime)
     lastTimeRef.current = timestamp
 
-    setState(prev => {
-      if (!prev.isPlaying) return prev
+    const prev = frameRef.current
+    if (!prev.isPlaying) {
+      animationRef.current = requestAnimationFrame(animateRef.current)
+      return
+    }
 
-      let newTime = prev.currentTime + deltaTime * prev.speed
-      let maxT = Math.max(prev.maxTimeReached, newTime)
-      let newEventIndex = prev.eventIndex
+    let newTime = prev.currentTime + deltaTime * prev.speed
+    let maxT = Math.max(prev.maxTimeReached, newTime)
+    let newEventIndex = prev.eventIndex
 
-      // Process events — thread state through each event
-      let currentState = prev
-      const newEvents: SimulationEvent[] = []
+    // Process events — thread state through each event
+    let currentState = prev
+    const newEvents: SimulationEvent[] = []
 
-      // Process events from the appropriate source as time advances
-      if (useMockData) {
-        // Mock mode: process from MOCK_SCENARIO
-        while (newEventIndex < MOCK_SCENARIO.length && MOCK_SCENARIO[newEventIndex].time <= newTime) {
-          const evt = MOCK_SCENARIO[newEventIndex]
-          currentState = processEventWithContext(evt, currentState)
-          newEvents.push(evt)
-          newEventIndex++
-        }
-      } else {
-        // Live mode: replay events from eventLog as time advances
-        // (This handles post-seek catch-up: after seeking backward, events
-        // between the seek target and the original time get re-processed
-        // as currentTime advances past them)
-        while (newEventIndex < currentState.eventLog.length && currentState.eventLog[newEventIndex].time <= newTime) {
-          const evt = currentState.eventLog[newEventIndex]
-          currentState = processEventWithContext(evt, currentState)
-          newEventIndex++
-        }
+    if (useMockData) {
+      while (newEventIndex < MOCK_SCENARIO.length && MOCK_SCENARIO[newEventIndex].time <= newTime) {
+        const evt = MOCK_SCENARIO[newEventIndex]
+        currentState = processEventWithContext(evt, currentState)
+        newEvents.push(evt)
+        newEventIndex++
       }
-
-      // Process NEW external events (from VS Code bridge)
-      // Copy and clear immediately to prevent stale closures from
-      // reprocessing the same events across multiple animation frames
-      if (externalEvents && externalEvents.length > 0) {
-        const eventsToProcess = externalEvents.slice()
-        onExternalEventsConsumed?.()
-        for (const event of eventsToProcess) {
-          // Filter by session if specified — use ref so we always read the
-          // latest value even if the animate closure hasn't been recreated yet.
-          // The ref is also updated synchronously via onSessionFilterChange callback
-          // so it's current even before React re-renders.
-          const activeFilter = sessionFilterRef.current
-          if (activeFilter && event.sessionId && event.sessionId !== activeFilter) {
-            continue
-          }
-          // Clamp event time to at least the current sim time so that
-          // bubbles/effects created by this event appear fresh, not pre-aged
-          const eventTime = Math.max(event.time || newTime, newTime)
-          const timedEvent = { ...event, time: eventTime }
-          // Advance currentTime so processEvent sees correct timestamps
-          // (critical for session-switch replay where many events arrive at once)
-          currentState = { ...currentState, currentTime: eventTime }
-          currentState = processEventWithContext(timedEvent, currentState)
-          newEvents.push(timedEvent)
-        }
-        // Sync simulation clock to latest event so active state renders correctly
-        newTime = Math.max(newTime, currentState.currentTime)
-        maxT = Math.max(maxT, newTime)
+    } else {
+      while (newEventIndex < currentState.eventLog.length && currentState.eventLog[newEventIndex].time <= newTime) {
+        const evt = currentState.eventLog[newEventIndex]
+        currentState = processEventWithContext(evt, currentState)
+        newEventIndex++
       }
+    }
 
-      // Append new events to log and advance eventIndex past them
-      if (newEvents.length > 0) {
-        let newLog = currentState.eventLog.concat(newEvents)
-        // Cap event log to prevent unbounded memory growth
-        if (newLog.length > MAX_EVENT_LOG) {
-          const drop = newLog.length - MAX_EVENT_LOG
-          newLog = newLog.slice(drop)
-          newEventIndex = newLog.length
-        } else {
-          newEventIndex = newLog.length
+    // Process external events (from VS Code bridge)
+    if (externalEvents && externalEvents.length > 0) {
+      const eventsToProcess = externalEvents.slice()
+      onExternalEventsConsumed?.()
+      for (const event of eventsToProcess) {
+        const activeFilter = sessionFilterRef.current
+        if (activeFilter && event.sessionId && event.sessionId !== activeFilter) {
+          continue
         }
-        currentState = { ...currentState, eventLog: newLog }
+        const eventTime = Math.max(event.time || newTime, newTime)
+        const timedEvent = { ...event, time: eventTime }
+        currentState = { ...currentState, currentTime: eventTime }
+        currentState = processEventWithContext(timedEvent, currentState)
+        newEvents.push(timedEvent)
       }
+      newTime = Math.max(newTime, currentState.currentTime)
+      maxT = Math.max(maxT, newTime)
+    }
 
-      // Update eventIndex on currentState before passing to computeNextFrame
-      currentState = { ...currentState, eventIndex: newEventIndex }
+    // Append new events to log
+    if (newEvents.length > 0) {
+      let newLog = currentState.eventLog.concat(newEvents)
+      if (newLog.length > MAX_EVENT_LOG) {
+        newLog = newLog.slice(newLog.length - MAX_EVENT_LOG)
+      }
+      // In mock mode, eventIndex tracks position in MOCK_SCENARIO (not the log).
+      // In live mode, eventIndex tracks position in the event log.
+      if (!useMockData) {
+        newEventIndex = newLog.length
+      }
+      currentState = { ...currentState, eventLog: newLog }
+    }
 
-      const result = computeNextFrame(prev, deltaTime, newTime, maxT, currentState, {
-        useMockData,
-        mockScenarioLength: MOCK_SCENARIO.length,
-        mockScenarioEndTime: MOCK_SCENARIO.length > 0 ? MOCK_SCENARIO[MOCK_SCENARIO.length - 1].time : 0,
-      })
+    currentState = { ...currentState, eventIndex: newEventIndex }
 
-      if (forceSimRef.current) forceSimRef.current.tick()
-
-      return result
+    const result = computeNextFrame(prev, deltaTime, newTime, maxT, currentState, {
+      useMockData,
+      mockScenarioLength: MOCK_SCENARIO.length,
+      mockScenarioEndTime: MOCK_SCENARIO.length > 0 ? MOCK_SCENARIO[MOCK_SCENARIO.length - 1].time : 0,
     })
 
+    // Write to frameRef (canvas reads this every frame)
+    frameRef.current = result
+
+    // Force tick — updates agent positions in frameRef
+    if (forceSimRef.current) forceSimRef.current.tick()
+
+    // Throttle React re-renders — UI updates at ~4/sec, canvas stays smooth via frameRef
+    if (newEvents.length > 0) {
+      if (!lastUIUpdateRef.current || timestamp - lastUIUpdateRef.current >= UI_THROTTLE_MS) {
+        setState(frameRef.current)
+        lastUIUpdateRef.current = timestamp
+      }
+    }
+
     animationRef.current = requestAnimationFrame(animateRef.current)
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- sessionFilter intentionally omitted; we read sessionFilterRef.current to avoid stale closures
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- sessionFilter intentionally omitted; we read sessionFilterRef.current
   }, [processEventWithContext, useMockData, externalEvents, onExternalEventsConsumed])
 
   animateRef.current = animate
@@ -273,67 +286,73 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     return () => { if (animationRef.current) cancelAnimationFrame(animationRef.current) }
   }, [state.isPlaying])
 
-  const play = useCallback(() => setState(prev => ({ ...prev, isPlaying: true })), [])
-  const pause = useCallback(() => setState(prev => ({ ...prev, isPlaying: false })), [])
+  // ─── Playback controls ───────────────────────────────────────────────────
+  const play = useCallback(() => {
+    const next = { ...frameRef.current, isPlaying: true }
+    commitState(next)
+  }, [commitState])
+
+  const pause = useCallback(() => {
+    const next = { ...frameRef.current, isPlaying: false }
+    commitState(next)
+  }, [commitState])
+
+  const setSpeed = useCallback((speed: number) => {
+    frameRef.current = { ...frameRef.current, speed }
+    setState(prev => ({ ...prev, speed }))
+  }, [])
 
   const restart = useCallback((keepActive = false) => {
     blockIdCounter.current = 0
     resetMsgIdCounter()
     if (!keepActive) {
-      setState(prev => createEmptyState({ isPlaying: true, speed: prev.speed }))
+      commitState(createEmptyState({ isPlaying: true, speed: frameRef.current.speed }))
       return
     }
-    // Keep active agents but clear completed state and visual history.
-    // Trim the event log to only agent_spawn events for surviving agents
-    // so seekToTime can reconstruct them during review mode.
-    setState(prev => {
-      const agents = new Map<string, Agent>()
-      for (const [id, agent] of prev.agents) {
-        if (agent.state !== 'complete') {
-          agents.set(id, { ...agent, toolCalls: 0, messageBubbles: [], timeAlive: 0 })
-        }
+    // Keep active agents but clear completed state and visual history
+    const prev = frameRef.current
+    const agents = new Map<string, Agent>()
+    for (const [id, agent] of prev.agents) {
+      if (agent.state !== 'complete') {
+        agents.set(id, { ...agent, toolCalls: 0, messageBubbles: [], timeAlive: 0 })
       }
+    }
 
-      const edges = prev.edges.filter(e =>
-        e.type === 'parent-child' && agents.has(e.from) && agents.has(e.to)
-      )
+    const edges = prev.edges.filter(e =>
+      e.type === 'parent-child' && agents.has(e.from) && agents.has(e.to)
+    )
 
-      const timelineEntries = new Map<string, TimelineEntry>()
-      for (const [id, entry] of prev.timelineEntries) {
-        if (agents.has(id)) {
-          timelineEntries.set(id, { ...entry, blocks: [] })
-        }
+    const timelineEntries = new Map<string, TimelineEntry>()
+    for (const [id, entry] of prev.timelineEntries) {
+      if (agents.has(id)) {
+        timelineEntries.set(id, { ...entry, blocks: [] })
       }
+    }
 
-      const conversations: SimulationState['conversations'] = new Map()
-      for (const id of agents.keys()) conversations.set(id, [])
+    const conversations: SimulationState['conversations'] = new Map()
+    for (const id of agents.keys()) conversations.set(id, [])
 
-      const eventLog = prev.eventLog.filter(e =>
-        e.type === 'agent_spawn' && agents.has(e.payload?.name as string)
-      )
+    const eventLog = prev.eventLog.filter(e =>
+      e.type === 'agent_spawn' && agents.has(e.payload?.name as string)
+    )
 
-      return {
-        ...createEmptyState({ isPlaying: true, speed: prev.speed }),
-        agents, edges, timelineEntries, conversations,
-        eventLog, eventIndex: eventLog.length,
-      }
-    })
-    // Re-sync force simulation with surviving agents
-    setTimeout(() => {
-      const s = stateRef.current
-      syncForceSimulation(s.agents, s.edges)
-    }, 0)
-  }, [syncForceSimulation])
-
-  const setSpeed = useCallback((speed: number) => setState(prev => ({ ...prev, speed })), [])
+    const next = {
+      ...createEmptyState({ isPlaying: true, speed: prev.speed }),
+      agents, edges, timelineEntries, conversations,
+      eventLog, eventIndex: eventLog.length,
+    }
+    commitState(next)
+    setTimeout(() => syncForceSimulation(next.agents, next.edges), 0)
+  }, [syncForceSimulation, commitState])
 
   const updateAgentPosition = useCallback((agentId: string, x: number, y: number) => {
-    setState(prev => {
-      const newAgents = new Map(prev.agents)
-      const agent = newAgents.get(agentId)
-      if (agent) newAgents.set(agentId, { ...agent, x, y, pinned: true })
-      return { ...prev, agents: newAgents }
-    })
+    // Drag updates — write to frameRef only (canvas reads it, no React render)
+    const prev = frameRef.current
+    const newAgents = new Map(prev.agents)
+    const agent = newAgents.get(agentId)
+    if (agent) newAgents.set(agentId, { ...agent, x, y, pinned: true })
+    frameRef.current = { ...prev, agents: newAgents }
+
     if (forceSimRef.current) {
       const node = forceSimRef.current.nodes().find(n => n.id === agentId)
       if (node) { node.fx = x; node.fy = y }
@@ -342,58 +361,50 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
 
   /** Seek to a specific time — replays events from scratch up to targetTime */
   const seekToTime = useCallback((targetTime: number) => {
-    setState(prev => {
-      // In mock mode, always use MOCK_SCENARIO (has all future events).
-      // In live mode, use the eventLog (only has events received so far).
-      const events = useMockData ? MOCK_SCENARIO : prev.eventLog
+    const prev = frameRef.current
+    const events = useMockData ? MOCK_SCENARIO : prev.eventLog
 
-      // Reset to blank state (preserve maxTimeReached for scrubber range)
-      let replayState = createEmptyState({
-        speed: prev.speed,
-        eventLog: prev.eventLog,
-        maxTimeReached: prev.maxTimeReached,
-      })
-
-      // Replay all events up to targetTime (suppress force sim during replay)
-      skipForceSyncRef.current = true
-      blockIdCounter.current = 0
-      let newEventIndex = 0
-      for (const event of events) {
-        if (event.time > targetTime) break
-        replayState.currentTime = event.time
-        replayState = { ...processEventWithContext(event, replayState), currentTime: event.time }
-        newEventIndex++
-      }
-      skipForceSyncRef.current = false
-
-      // Snap visual state analytically
-      replayState = snapVisualState(replayState, targetTime)
-      replayState.currentTime = targetTime
-      replayState.eventIndex = newEventIndex
-
-      // Single force simulation sync with the final state
-      setTimeout(() => syncForceSimulation(replayState.agents, replayState.edges), 0)
-
-      return replayState
+    let replayState = createEmptyState({
+      speed: prev.speed,
+      eventLog: prev.eventLog,
+      maxTimeReached: prev.maxTimeReached,
     })
-  }, [processEventWithContext, useMockData, syncForceSimulation])
 
-  // ─── Session state save/restore ────────────────────────────────────────────
-  const stateRef = useRef(state)
-  stateRef.current = state
+    skipForceSyncRef.current = true
+    blockIdCounter.current = 0
+    let newEventIndex = 0
+    for (const event of events) {
+      if (event.time > targetTime) break
+      replayState.currentTime = event.time
+      replayState = { ...processEventWithContext(event, replayState), currentTime: event.time }
+      newEventIndex++
+    }
+    skipForceSyncRef.current = false
 
+    replayState = snapVisualState(replayState, targetTime)
+    replayState.currentTime = targetTime
+    replayState.eventIndex = newEventIndex
+
+    commitState(replayState)
+    setTimeout(() => syncForceSimulation(replayState.agents, replayState.edges), 0)
+  }, [processEventWithContext, useMockData, syncForceSimulation, commitState])
+
+  // ─── Session state save/restore ──────────────────────────────────────────
   const saveSnapshot = useCallback((): { simState: SimulationState; blockId: number } => ({
-    simState: stateRef.current,
+    simState: frameRef.current,
     blockId: blockIdCounter.current,
   }), [])
 
   const restoreSnapshot = useCallback((snapshot: { simState: SimulationState; blockId: number }) => {
     blockIdCounter.current = snapshot.blockId
-    setState({ ...snapshot.simState, isPlaying: true })
+    commitState({ ...snapshot.simState, isPlaying: true })
     setTimeout(() => syncForceSimulation(snapshot.simState.agents, snapshot.simState.edges), 0)
-  }, [syncForceSimulation])
+  }, [syncForceSimulation, commitState])
 
   return {
+    // Canvas reads frameRef directly for 60fps rendering
+    frameRef,
+    // UI components use React state (updated only on events/user actions)
     agents: state.agents, toolCalls: state.toolCalls,
     particles: state.particles, edges: state.edges,
     discoveries: state.discoveries,

--- a/web/hooks/use-canvas-interaction.ts
+++ b/web/hooks/use-canvas-interaction.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, type MutableRefObject } from 'react'
+import { useState, useCallback, useRef, useEffect, type MutableRefObject } from 'react'
 import { Agent, ToolCallNode, Discovery, ANIM } from '@/lib/agent-types'
 import { CAMERA } from '@/lib/canvas-constants'
 import {
@@ -175,7 +175,9 @@ export function useCanvasInteraction({
     dragTargetRef.current = null
   }, [screenToCanvas, findAgentAt, findBubbleAgentAt, findToolCallAt, findDiscoveryAt, drawPropsRef, panVelocityRef])
 
-  const handleWheel = useCallback((e: React.WheelEvent) => {
+  // Wheel handler attached as native event (passive: false) to allow preventDefault
+  const handleWheelRef = useRef<(e: WheelEvent) => void>(() => {})
+  handleWheelRef.current = (e: WheelEvent) => {
     e.preventDefault()
     userHasNavigatedRef.current = true
     if (e.ctrlKey || e.metaKey) {
@@ -191,7 +193,14 @@ export function useCanvasInteraction({
       const prev = transformRef.current
       transformRef.current = { ...prev, x: prev.x - e.deltaX, y: prev.y - e.deltaY }
     }
-  }, [userHasNavigatedRef, mainCanvasRef, transformRef])
+  }
+  useEffect(() => {
+    const canvas = mainCanvasRef.current
+    if (!canvas) return
+    const handler = (e: WheelEvent) => handleWheelRef.current(e)
+    canvas.addEventListener('wheel', handler, { passive: false })
+    return () => canvas.removeEventListener('wheel', handler)
+  }, [mainCanvasRef])
 
   const handleDoubleClick = useCallback(() => {
     doZoomToFit()
@@ -235,7 +244,6 @@ export function useCanvasInteraction({
       onMouseDown: handleMouseDown,
       onMouseMove: handleMouseMove,
       onMouseUp: handleMouseUp,
-      onWheel: handleWheel,
       onDoubleClick: handleDoubleClick,
       onContextMenu: handleContextMenuEvent,
       onMouseLeave: handleMouseLeave,

--- a/web/hooks/use-virtual-list.ts
+++ b/web/hooks/use-virtual-list.ts
@@ -1,0 +1,162 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { AUTO_SCROLL_THRESHOLD } from '@/lib/canvas-constants'
+
+const OVERSCAN = 10
+
+interface UseVirtualListOptions {
+  gap: number
+  initialViewportHeight?: number
+  autoScroll?: boolean
+}
+
+/**
+ * Virtual list with exact measurement — no height estimation.
+ *
+ * Items are rendered and measured on mount. Only measured heights contribute
+ * to totalHeight and positioning. New items are always rendered (via an
+ * extended render window) so they get measured immediately.
+ */
+export function useVirtualList<T extends { id: string }>(
+  items: readonly T[],
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  options: UseVirtualListOptions,
+) {
+  const { gap, initialViewportHeight = 300, autoScroll = false } = options
+  const [scrollTop, setScrollTop] = useState(0)
+  const [viewportHeight, setViewportHeight] = useState(initialViewportHeight)
+  const [measureTick, setMeasureTick] = useState(0)
+  const heightsRef = useRef<Map<string, number>>(new Map())
+  const autoScrollRef = useRef(true)
+  const [isAtBottom, setIsAtBottom] = useState(true)
+
+  // Reset when items go from empty to populated (panel reopen)
+  const wasEmptyRef = useRef(true)
+  if (items.length === 0) {
+    wasEmptyRef.current = true
+  } else if (wasEmptyRef.current) {
+    wasEmptyRef.current = false
+    heightsRef.current.clear()
+    autoScrollRef.current = true
+  }
+
+  const isPinned = autoScroll && autoScrollRef.current
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    if (autoScroll) {
+      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < AUTO_SCROLL_THRESHOLD
+      autoScrollRef.current = atBottom
+      setIsAtBottom(atBottom)
+      if (atBottom) return
+    }
+    setScrollTop(el.scrollTop)
+  }, [containerRef, autoScroll])
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) setViewportHeight(entry.contentRect.height)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [containerRef])
+
+  // ── Layout: only use measured heights ─────────────────────────────────────
+  const heights = heightsRef.current
+  let totalHeight = 0
+  const offsets: number[] = []
+  for (const item of items) {
+    offsets.push(totalHeight)
+    const h = heights.get(item.id)
+    if (h != null) totalHeight += h + gap
+    // Unmeasured items: offset stays at current totalHeight (stacked at end),
+    // height = 0 in totalHeight until measured
+  }
+
+  // ── Visible window ────────────────────────────────────────────────────────
+  // Read scrollTop directly from DOM to avoid stale-state lag
+  const liveScrollTop = (!isPinned && containerRef.current)
+    ? containerRef.current.scrollTop
+    : scrollTop
+
+  let startIdx: number
+  let endIdx: number
+
+  if (isPinned && items.length > 0) {
+    // Pinned: render from the end
+    endIdx = items.length
+    let filled = 0
+    startIdx = items.length
+    for (let i = items.length - 1; i >= 0; i--) {
+      const h = heights.get(items[i].id)
+      if (h != null) filled += h + gap
+      startIdx = i
+      if (filled > viewportHeight + 200) break // extra buffer
+    }
+    startIdx = Math.max(0, startIdx - OVERSCAN)
+  } else {
+    // Normal scroll: find first item whose bottom edge is past scrollTop
+    let lo = 0
+    for (lo = 0; lo < items.length; lo++) {
+      const h = heights.get(items[lo].id)
+      if (h == null) continue // unmeasured items have no height yet — keep looking
+      if (offsets[lo] + h + gap >= liveScrollTop) break
+    }
+    startIdx = Math.max(0, lo - OVERSCAN)
+
+    // Find last item whose top edge is before viewport bottom
+    endIdx = startIdx
+    for (let i = lo; i < items.length; i++) {
+      const h = heights.get(items[i].id)
+      endIdx = i + 1
+      if (h != null && offsets[i] > liveScrollTop + viewportHeight) {
+        endIdx = Math.min(items.length, i + OVERSCAN + 1)
+        break
+      }
+    }
+    endIdx = Math.min(items.length, Math.max(endIdx, startIdx + OVERSCAN + 1))
+  }
+
+  // Always render unmeasured items at the end so they get measured
+  for (let i = endIdx; i < items.length; i++) {
+    if (!heights.has(items[i].id)) endIdx = i + 1
+    else break
+  }
+
+  const visibleItems = items.slice(startIdx, endIdx)
+  const offsetTop = startIdx < offsets.length ? offsets[startIdx] : 0
+
+  // ── Trigger re-render after measurements ──────────────────────────────────
+  const measureRef = useCallback((id: string, el: HTMLDivElement | null) => {
+    if (!el) return
+    const h = el.offsetHeight
+    if (heights.get(id) !== h) {
+      heights.set(id, h)
+      // Force re-render to recalculate layout with real heights
+      setMeasureTick(n => n + 1)
+    }
+  }, [heights])
+
+  // ── Auto-scroll after layout settles ──────────────────────────────────────
+  useEffect(() => {
+    if (autoScroll && autoScrollRef.current && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+  }, [autoScroll, containerRef, items.length, measureTick])
+
+  const scrollToBottom = useCallback(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+      autoScrollRef.current = true
+      setIsAtBottom(true)
+    }
+  }, [containerRef])
+
+  return {
+    visibleItems, totalHeight, offsetTop,
+    handleScroll, measureRef,
+    isAtBottom, scrollToBottom,
+  }
+}

--- a/web/lib/canvas-constants.ts
+++ b/web/lib/canvas-constants.ts
@@ -90,7 +90,14 @@ export const ANIM_SPEED = {
   maxDeltaTime: 0.1,
   /** Default delta time when time info unavailable */
   defaultDeltaTime: 0.016,
+  /** Minimum ms between frames (60fps cap, with 1ms slack for timing jitter) */
+  minFrameInterval: (1000 / 60) - 1,
 } as const
+
+// ─── UI panel constants ─────────────────────────────────────────────────────
+
+/** Distance from bottom (px) before a scroll container is considered "at bottom" */
+export const AUTO_SCROLL_THRESHOLD = 60
 
 // ─── Camera / interaction constants ─────────────────────────────────────────
 
@@ -347,6 +354,34 @@ export const PARTICLE_DRAW = {
   labelMaxT: 0.8,
   labelFontSize: 8,
   labelYOffset: -12,
+} as const
+
+// ─── Performance overlay constants (debug only, ?perf or ?stress) ────────────
+
+/** Cached once at module load — avoids parsing location.search every frame */
+export const PERF_OVERLAY_ENABLED = typeof window !== 'undefined'
+  && (() => {
+    const p = new URLSearchParams(window.location.search)
+    return p.has('perf') || p.has('stress')
+  })()
+
+export const PERF_OVERLAY = {
+  x: 8,
+  y: 8,
+  width: 260,
+  height: 140,
+  padding: 8,
+  lineHeight: 18,
+  font: '12px monospace',
+  maxFrameSamples: 120,
+  fpsWarning: 30,
+  fpsCaution: 50,
+  updateIntervalMs: 1000,
+  bgColor: 'rgba(0, 0, 0, 0.75)',
+  fpsGoodColor: '#44ff44',
+  fpsCautionColor: '#ffaa00',
+  fpsWarningColor: '#ff4444',
+  textColor: '#cccccc',
 } as const
 
 // ─── Hit detection constants ────────────────────────────────────────────────

--- a/web/lib/mock-scenario.ts
+++ b/web/lib/mock-scenario.ts
@@ -1,10 +1,29 @@
 import type { SimulationEvent } from './agent-types'
+import { STRESS_SCENARIOS, type StressLevel } from './stress-test-scenario'
+
+// ─── Stress Test Support ─────────────────────────────────────────────────────
+// Add ?stress=light|medium|heavy|extreme to the URL to load a stress scenario.
+// This replaces the normal mock scenario for profiling purposes.
+
+function getStressLevel(): StressLevel | null {
+  if (typeof window === 'undefined') return null
+  const params = new URLSearchParams(window.location.search)
+  const level = params.get('stress')
+  if (level && level in STRESS_SCENARIOS) return level as StressLevel
+  return null
+}
+
+const stressLevel = getStressLevel()
+if (stressLevel) {
+  // eslint-disable-next-line no-console
+  console.log(`[stress-test] Loading ${stressLevel} stress scenario...`)
+}
 
 // ─── Rich Mock Scenario ──────────────────────────────────────────────────────
 // Demonstrates a full agent session: user prompt → research → parallel subagents
 // → implementation → testing with error recovery → completion
 
-export const MOCK_SCENARIO: SimulationEvent[] = [
+const NORMAL_MOCK_SCENARIO: SimulationEvent[] = [
   // ── Agent Spawn & User Prompt ─────────────────────────────────────────────
   { time: 0.0, type: 'agent_spawn', payload: { name: 'orchestrator', isMain: true, task: 'Waiting for instructions...' } },
   { time: 0.2, type: 'message', payload: { agent: 'orchestrator', role: 'user', content: 'Refactor the payment system to support Stripe and PayPal, add webhook handling, and write integration tests' } },
@@ -193,4 +212,10 @@ export const MOCK_SCENARIO: SimulationEvent[] = [
   { time: 65.0, type: 'agent_complete', payload: { name: 'orchestrator' } },
 ]
 
-export const MOCK_DURATION = MOCK_SCENARIO[MOCK_SCENARIO.length - 1].time + 10
+export const MOCK_SCENARIO: SimulationEvent[] = stressLevel
+  ? STRESS_SCENARIOS[stressLevel]()
+  : NORMAL_MOCK_SCENARIO
+
+export const MOCK_DURATION = MOCK_SCENARIO.length > 0
+  ? MOCK_SCENARIO[MOCK_SCENARIO.length - 1].time + 10
+  : 0

--- a/web/lib/stress-test-scenario.ts
+++ b/web/lib/stress-test-scenario.ts
@@ -1,0 +1,193 @@
+import type { SimulationEvent } from './agent-types'
+
+/**
+ * Stress-test scenario generator.
+ *
+ * Generates a large number of agents, tool calls, messages, and subagent
+ * interactions to simulate a heavy long-running session for profiling.
+ *
+ * Use with ?stress query param or by toggling STRESS_TEST in mock-scenario.ts
+ */
+
+interface StressConfig {
+  /** Number of "waves" of subagent work (default: 8) */
+  waves: number
+  /** Subagents per wave (default: 6) */
+  subagentsPerWave: number
+  /** Tool calls per subagent (default: 10) */
+  toolCallsPerSubagent: number
+  /** Messages per subagent (default: 4) */
+  messagesPerSubagent: number
+  /** Extra tool calls on orchestrator between waves (default: 3) */
+  orchestratorToolCallsPerWave: number
+}
+
+const DEFAULT_CONFIG: StressConfig = {
+  waves: 8,
+  subagentsPerWave: 6,
+  toolCallsPerSubagent: 10,
+  messagesPerSubagent: 4,
+  orchestratorToolCallsPerWave: 3,
+}
+
+const TOOL_NAMES = ['Read', 'Write', 'Edit', 'Grep', 'Glob', 'Bash', 'WebSearch', 'WebFetch', 'TodoWrite']
+const FILE_PATHS = [
+  'src/services/auth.ts', 'src/services/payment.ts', 'src/routes/api.ts',
+  'src/models/user.ts', 'src/utils/crypto.ts', 'src/middleware/cors.ts',
+  'src/config/database.ts', 'src/workers/email.ts', 'src/hooks/useAuth.tsx',
+  'src/components/Dashboard.tsx', 'src/lib/cache.ts', 'src/routes/webhook.ts',
+  'tests/integration/auth.test.ts', 'tests/unit/payment.test.ts',
+]
+const TASK_DESCRIPTIONS = [
+  'Refactor authentication middleware',
+  'Analyze database query performance',
+  'Research API rate limiting strategies',
+  'Implement caching layer',
+  'Fix race condition in worker queue',
+  'Update payment webhooks',
+  'Add CORS configuration',
+  'Write integration tests for auth flow',
+  'Migrate to new SDK version',
+  'Profile memory usage in workers',
+  'Investigate slow query in dashboard',
+  'Add input validation layer',
+]
+
+function pick<T>(arr: T[], i: number): T {
+  return arr[i % arr.length]
+}
+
+export function generateStressScenario(config: Partial<StressConfig> = {}): SimulationEvent[] {
+  const cfg = { ...DEFAULT_CONFIG, ...config }
+  const events: SimulationEvent[] = []
+  let t = 0
+
+  const emit = (type: SimulationEvent['type'], payload: Record<string, unknown>, dt = 0.1) => {
+    t += dt
+    events.push({ time: t, type, payload })
+  }
+
+  // Spawn orchestrator
+  emit('agent_spawn', { name: 'orchestrator', isMain: true, task: 'Stress test: multi-wave parallel agent work' })
+  emit('message', { agent: 'orchestrator', role: 'user', content: 'Run comprehensive analysis and refactoring across the entire codebase with parallel agents' })
+  emit('context_update', { agent: 'orchestrator', tokens: 3000, breakdown: { systemPrompt: 1500, userMessages: 1500, toolResults: 0, reasoning: 0, subagentResults: 0 } })
+
+  let subagentCounter = 0
+
+  for (let wave = 0; wave < cfg.waves; wave++) {
+    // Orchestrator thinks and does some work between waves
+    emit('message', { agent: 'orchestrator', role: 'thinking', content: `Planning wave ${wave + 1}: dispatching ${cfg.subagentsPerWave} agents for parallel work...` }, 0.5)
+    emit('message', { agent: 'orchestrator', content: `Starting wave ${wave + 1} of ${cfg.waves}...` }, 0.3)
+
+    // Orchestrator tool calls between waves
+    for (let i = 0; i < cfg.orchestratorToolCallsPerWave; i++) {
+      const tool = pick(TOOL_NAMES, wave * 10 + i)
+      const file = pick(FILE_PATHS, wave * 10 + i)
+      emit('tool_call_start', { agent: 'orchestrator', tool, args: file, inputData: { file_path: file } }, 0.2)
+      emit('tool_call_end', { agent: 'orchestrator', tool, result: `Processed ${file} — ${50 + (wave * i * 7) % 200} lines`, tokenCost: 300 + (wave * 100) }, 0.3)
+    }
+
+    emit('context_update', {
+      agent: 'orchestrator',
+      tokens: 3000 + wave * 5000,
+      breakdown: {
+        systemPrompt: 1500, userMessages: 1500,
+        toolResults: 1000 * (wave + 1),
+        reasoning: 500 * (wave + 1),
+        subagentResults: wave * 3000,
+      },
+    }, 0.1)
+
+    // Spawn subagents for this wave
+    const waveAgents: string[] = []
+    for (let s = 0; s < cfg.subagentsPerWave; s++) {
+      subagentCounter++
+      const name = `agent-w${wave}-s${s}`
+      const task = pick(TASK_DESCRIPTIONS, subagentCounter)
+      waveAgents.push(name)
+
+      emit('subagent_dispatch', { parent: 'orchestrator', child: name, task }, 0.05)
+      emit('agent_spawn', { name, parent: 'orchestrator', task }, 0.05)
+      emit('context_update', {
+        agent: name,
+        tokens: 1800,
+        breakdown: { systemPrompt: 1400, userMessages: 400, toolResults: 0, reasoning: 0, subagentResults: 0 },
+      }, 0.05)
+    }
+
+    // Subagents work in parallel (interleaved events to simulate concurrency)
+    for (let toolIdx = 0; toolIdx < cfg.toolCallsPerSubagent; toolIdx++) {
+      for (let s = 0; s < cfg.subagentsPerWave; s++) {
+        const agentName = waveAgents[s]
+        const tool = pick(TOOL_NAMES, subagentCounter * 100 + toolIdx * 10 + s)
+        const file = pick(FILE_PATHS, toolIdx * cfg.subagentsPerWave + s)
+
+        emit('tool_call_start', { agent: agentName, tool, args: file, inputData: { file_path: file } }, 0.05)
+        emit('tool_call_end', {
+          agent: agentName, tool,
+          result: `Result from ${file}: ${20 + (toolIdx * s * 3) % 150} matches`,
+          tokenCost: 200 + toolIdx * 50,
+          ...(toolIdx === 0 && s === 0 ? {
+            discovery: { type: 'finding', label: `Wave ${wave} finding`, content: `Important pattern found in ${file}` },
+          } : {}),
+        }, 0.1)
+
+        // Sprinkle messages
+        if (toolIdx % Math.max(1, Math.floor(cfg.toolCallsPerSubagent / cfg.messagesPerSubagent)) === 0) {
+          emit('message', { agent: agentName, role: 'thinking', content: `Analyzing ${file} for patterns...` }, 0.05)
+        }
+        if (toolIdx === Math.floor(cfg.toolCallsPerSubagent / 2)) {
+          emit('message', { agent: agentName, content: `Found ${3 + s} relevant patterns so far...` }, 0.05)
+        }
+      }
+    }
+
+    // Context updates for subagents
+    for (let s = 0; s < cfg.subagentsPerWave; s++) {
+      emit('context_update', {
+        agent: waveAgents[s],
+        tokens: 1800 + cfg.toolCallsPerSubagent * 300,
+        breakdown: {
+          systemPrompt: 1400, userMessages: 400,
+          toolResults: cfg.toolCallsPerSubagent * 200,
+          reasoning: cfg.toolCallsPerSubagent * 100,
+          subagentResults: 0,
+        },
+      }, 0.02)
+    }
+
+    // Complete subagents
+    for (let s = 0; s < cfg.subagentsPerWave; s++) {
+      emit('subagent_return', {
+        child: waveAgents[s], parent: 'orchestrator',
+        summary: `Completed analysis: found ${3 + s} patterns, modified ${1 + s % 3} files`,
+      }, 0.1)
+      emit('agent_complete', { name: waveAgents[s] }, 0.05)
+    }
+  }
+
+  // Final orchestrator completion
+  emit('message', { agent: 'orchestrator', content: `All ${cfg.waves} waves complete. ${subagentCounter} agents spawned, comprehensive analysis done.` }, 0.5)
+  emit('context_update', {
+    agent: 'orchestrator',
+    tokens: 80000,
+    breakdown: { systemPrompt: 1500, userMessages: 1500, toolResults: 15000, reasoning: 22000, subagentResults: 40000 },
+  }, 0.2)
+  emit('agent_complete', { name: 'orchestrator' }, 1.0)
+
+  return events
+}
+
+/** Pre-built scenarios at various load levels */
+export const STRESS_SCENARIOS = {
+  /** ~200 events, 12 subagents — light load */
+  light: () => generateStressScenario({ waves: 2, subagentsPerWave: 3, toolCallsPerSubagent: 5 }),
+  /** ~1500 events, 48 subagents — medium load */
+  medium: () => generateStressScenario({ waves: 8, subagentsPerWave: 6, toolCallsPerSubagent: 10 }),
+  /** ~4000 events, 120 subagents — heavy load */
+  heavy: () => generateStressScenario({ waves: 15, subagentsPerWave: 8, toolCallsPerSubagent: 15, messagesPerSubagent: 6 }),
+  /** ~8000+ events, 240 subagents — extreme load (will likely cause the reported lag) */
+  extreme: () => generateStressScenario({ waves: 20, subagentsPerWave: 12, toolCallsPerSubagent: 20, messagesPerSubagent: 8, orchestratorToolCallsPerWave: 5 }),
+}
+
+export type StressLevel = keyof typeof STRESS_SCENARIOS


### PR DESCRIPTION
Decouple canvas rendering from React state updates — canvas reads from a frameRef at 60fps while React only re-renders UI on structural data changes (~4/sec). Virtualize transcript and message feed panels, replace timeline DOM with canvas rendering, and fix tool call cleanup leak that caused unbounded object accumulation after ~5000 events.

## What does this PR do?

Fixes #20 — heavy performance degradation during long sessions with many agents/tool calls.

**Root causes identified and fixed:**

- **React re-rendering every animation frame** — `setState` in the rAF loop triggered full component tree reconciliation 60x/sec. Canvas now reads from a `frameRef` directly; React state updates only on structural data changes, throttled to ~4/sec.
- **Hidden panels doing full computation** — `TimelinePanel` and `FileAttentionPanel` sorted and rendered thousands of DOM elements even when not visible. Now early-return `null` when hidden.
- **O(n log n) sorts on every event** — `timelineEvents`, message feed memos rebuilt and sorted all data on each state update. Replaced with incremental append caches.
- **Unbounded DOM rendering in panels** — Timeline rewritten as canvas. Transcript and message feed virtualized (only visible items rendered).
- **Tool call cleanup leak** — cleanup only found faded tool calls via edges; if the edge was removed first, the tool call stayed forever. Now scans all tool calls directly.
- **Event log cap causing mass replay** — at 5000 events, the log cap reset `eventIndex` which in mock mode replayed thousands of events in a single frame. Mock mode now preserves its index independently.
- **60fps cap** — simulation loop capped at 60fps to halve CPU/GPU usage (was running at display refresh rate, 120fps on many machines).

**Additional improvements:**

- `TopBar` memoized with primitive `agentCount` prop instead of `agents` Map
- File attention panel shows agent count instead of full agent name list
- Scrubber event dots span full bar width relative to last event
- Passive wheel event listener fix (eliminates console warning)
- Stress test scenario generator (`?stress=light|medium|heavy|extreme`) and performance overlay (`?perf`) for profiling

## How to test

1. Run `cd web && pnpm dev`
2. Open `http://localhost:3000?stress=extreme` — 14k events, 240 agents
3. Verify FPS stays stable (shown in top-left overlay) through the full scenario
4. Open each panel (Timeline, Chat, Transcript, Files) while running — FPS should remain stable
5. Test scrolling in Transcript and Message Feed panels — items should appear/disappear smoothly
6. Test review mode (pause → scrub) — playhead should start at current position
7. Normal mock scenario (`http://localhost:3000`) should work unchanged

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)