### PR TITLE
Add standalone web app with npx support (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 extension/README.md
 scripts/.dev-relay.js
 scripts/.dev-relay.js.map
+app/dist/
 next-env.d.ts
 *.tsbuildinfo
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,20 @@ Claude Code is powerful, but its execution is a black box — you see the final 
 
 ## Getting Started
 
-### Standalone Web App (no VS Code required)
+### Quick Start (no VS Code required)
 
-Use Agent Flow directly in your browser — works with Claude Code in any terminal.
+```bash
+npx agent-flow-app
+```
+
+This starts the visualizer in your browser. Start a Claude Code session in another terminal — events will stream in real-time.
+
+Options:
+- `--port <number>` — change the server port (default: 3001)
+- `--no-open` — don't open the browser automatically
+- `--verbose` — show detailed event logs
+
+### Standalone Web App (from source)
 
 ```bash
 git clone https://github.com/patoles/agent-flow.git

--- a/app/build.js
+++ b/app/build.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Builds the standalone web app package:
+ *   1. Builds the webview UI via Vite (into app/dist/webview/)
+ *   2. Bundles the app entry via esbuild (into app/dist/app.js)
+ */
+'use strict'
+
+const { execSync } = require('child_process')
+const esbuild = require('esbuild')
+const path = require('path')
+
+const ROOT = path.join(__dirname, '..')
+const APP_DIR = __dirname
+
+console.log('Building Agent Flow app...\n')
+
+// 1. Build the webview UI
+console.log('[1/2] Building webview...')
+execSync('npx vite build --config vite.config.app.ts', {
+  cwd: path.join(ROOT, 'web'),
+  stdio: 'inherit',
+})
+
+// 2. Bundle the app
+console.log('\n[2/2] Bundling app...')
+esbuild.buildSync({
+  entryPoints: [path.join(APP_DIR, 'src', 'app.ts')],
+  bundle: true,
+  platform: 'node',
+  target: 'node18',
+  outfile: path.join(APP_DIR, 'dist', 'app.js'),
+  alias: {
+    'vscode': path.join(ROOT, 'scripts', 'vscode-shim.js'),
+  },
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+  sourcemap: false,
+  logLevel: 'warning',
+})
+
+console.log('\nDone! Package ready in app/dist/')

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "agent-flow-app",
+  "version": "0.6.1",
+  "description": "Real-time visualization of AI agent orchestration — standalone web app",
+  "bin": {
+    "agent-flow": "dist/app.js"
+  },
+  "files": [
+    "dist/"
+  ],
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patoles/agent-flow"
+  },
+  "keywords": [
+    "agent",
+    "visualization",
+    "ai",
+    "llm",
+    "agent-flow"
+  ]
+}

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -1,0 +1,29 @@
+/**
+ * Agent Flow — standalone web app for visualizing AI agent orchestration.
+ *
+ * Starts a local server that:
+ *   1. Receives events from agent hooks
+ *   2. Watches JSONL transcript files for active sessions
+ *   3. Serves the visualizer UI and streams events via SSE
+ *   4. Opens the browser automatically
+ *
+ * Usage: npx @agent-flow/app [--port <number>] [--no-open]
+ */
+import { parseArgs } from './args'
+import { ensureSetup } from '../../scripts/setup'
+import { startServer } from './server'
+
+const args = parseArgs(process.argv.slice(2))
+
+console.log('Agent Flow\n')
+
+// Ensure hooks are configured
+ensureSetup()
+
+// Start the server
+startServer({
+  port: args.port,
+  openBrowser: args.open,
+  workspace: process.cwd(),
+  verbose: args.verbose,
+})

--- a/app/src/args.ts
+++ b/app/src/args.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_RELAY_PORT } from '../../extension/src/constants'
+
+/** Parse CLI arguments. Keeps it simple — no dependencies. */
+export function parseArgs(argv: string[]) {
+  let port = DEFAULT_RELAY_PORT
+  let open = true
+  let verbose = false
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if ((arg === '--port' || arg === '-p') && argv[i + 1]) {
+      const n = parseInt(argv[i + 1], 10)
+      if (!isNaN(n) && n > 0 && n < 65536) port = n
+      i++
+    } else if (arg === '--no-open') {
+      open = false
+    } else if (arg === '--verbose' || arg === '-v') {
+      verbose = true
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`
+Usage: agent-flow [options]
+
+Options:
+  -p, --port <number>  Port for the server (default: ${DEFAULT_RELAY_PORT})
+  --no-open            Don't open the browser automatically
+  -v, --verbose        Show detailed event logs
+  -h, --help           Show this help message
+`)
+      process.exit(0)
+    }
+  }
+
+  return { port, open, verbose }
+}

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -1,0 +1,66 @@
+/**
+ * Combined HTTP server: serves the visualizer UI and streams events via SSE.
+ * Reuses the extension's hook server, transcript parser, and session watcher.
+ */
+import * as http from 'http'
+import { exec, execFile } from 'child_process'
+
+import { createRelay } from '../../scripts/relay'
+import { serveStatic } from './static'
+
+interface ServerOptions {
+  port: number
+  openBrowser: boolean
+  workspace: string
+  verbose?: boolean
+}
+
+export async function startServer(options: ServerOptions) {
+  const { port, openBrowser, workspace } = options
+
+  const relay = await createRelay({ workspace, verbose: options.verbose })
+
+  const server = http.createServer((req, res) => {
+    // SSE endpoint
+    if (req.url === '/events') {
+      return relay.handleSSE(req, res)
+    }
+
+    // Static files (UI)
+    if (req.method === 'GET') {
+      return serveStatic(req, res)
+    }
+
+    res.writeHead(404)
+    res.end('Not found')
+  })
+
+  server.listen(port, '127.0.0.1', () => {
+    const url = `http://127.0.0.1:${port}`
+    console.log(`Server running at ${url}`)
+    console.log('Waiting for agent events...\n')
+
+    if (openBrowser) {
+      openURL(url)
+    }
+  })
+
+  // Cleanup on exit
+  function cleanup() {
+    server.close()
+    relay.dispose()
+    process.exit(0)
+  }
+  process.on('SIGINT', cleanup)
+  process.on('SIGTERM', cleanup)
+}
+
+function openURL(url: string) {
+  if (process.platform === 'win32') {
+    // 'start' is a shell builtin on Windows — must use exec, not execFile
+    exec(`start "" "${url}"`)
+  } else {
+    const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open'
+    execFile(cmd, [url], () => {})
+  }
+}

--- a/app/src/static.ts
+++ b/app/src/static.ts
@@ -1,0 +1,69 @@
+/**
+ * Static file server for the pre-built webview assets.
+ * Serves index.html, index.js, and index.css from app/dist/webview/.
+ */
+import * as http from 'http'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const WEBVIEW_DIR = path.join(__dirname, 'webview')
+
+const HTML_SHELL = `<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Flow</title>
+  <link rel="stylesheet" href="/index.css">
+  <style>html, body { height: 100%; margin: 0; padding: 0; }</style>
+</head>
+<body class="font-sans antialiased" style="background: #0a0a1a;">
+  <div id="root" style="height: 100%;"></div>
+  <script src="/index.js"></script>
+</body>
+</html>`
+
+const MIME_TYPES: Record<string, string> = {
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.html': 'text/html',
+}
+
+export function serveStatic(req: http.IncomingMessage, res: http.ServerResponse) {
+  const url = req.url || '/'
+
+  if (url === '/' || url === '/index.html') {
+    res.writeHead(200, { 'Content-Type': 'text/html' })
+    res.end(HTML_SHELL)
+    return
+  }
+
+  // Only serve known asset files from the webview directory
+  const basename = path.basename(url)
+  const ext = path.extname(basename)
+  const mime = MIME_TYPES[ext]
+
+  if (!mime) {
+    res.writeHead(404)
+    res.end('Not found')
+    return
+  }
+
+  const filePath = path.join(WEBVIEW_DIR, basename)
+
+  // Prevent path traversal
+  if (!filePath.startsWith(WEBVIEW_DIR)) {
+    res.writeHead(403)
+    res.end('Forbidden')
+    return
+  }
+
+  try {
+    const content = fs.readFileSync(filePath)
+    res.writeHead(200, { 'Content-Type': mime })
+    res.end(content)
+  } catch {
+    res.writeHead(404)
+    res.end('Not found')
+  }
+}

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1
+
+- npx support — `npx agent-flow-app` starts the visualizer without cloning the repo
+- Internal refactor: shared relay module and build config
+
 ## 0.6.0
 
 - Standalone web app — run Agent Flow in the browser without VS Code (`pnpm run dev`)

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-flow",
   "displayName": "Agent Flow",
   "description": "Real-time visualization of Claude Code agent orchestration",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "simon-p",
   "license": "Apache-2.0",
   "repository": {

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -37,6 +37,12 @@ export const BRIDGE_INIT_RETRY_MS = 100
 /** Default dev server port */
 export const DEFAULT_DEV_PORT = 3002
 
+/** Default SSE relay port (used by dev relay, standalone app, and webview build) */
+export const DEFAULT_RELAY_PORT = 3001
+
+/** Default dev web app origin (for CORS in dev relay) */
+export const DEV_WEB_ORIGIN = 'http://localhost:3000'
+
 /** Returned by HookServer.start() when the port is already in use by another instance */
 export const HOOK_SERVER_NOT_STARTED = -1
 

--- a/extension/src/logger.ts
+++ b/extension/src/logger.ts
@@ -8,6 +8,11 @@ const LOG_LEVELS: Record<string, number> = { debug: 0, info: 1, warn: 2, error: 
 
 let minLevel = 'info'
 
+/** Set the minimum log level (debug, info, warn, error) */
+export function setLogLevel(level: string) {
+  if (level in LOG_LEVELS) minLevel = level
+}
+
 function shouldLog(level: string): boolean {
   return (LOG_LEVELS[level] ?? 0) >= (LOG_LEVELS[minLevel] ?? 0)
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:extension": "pnpm --filter agent-flow run build",
     "build:web": "pnpm --filter agent-flow-web run build",
     "build:webview": "pnpm --filter agent-flow-web run build:webview",
-    "build:all": "pnpm run build:webview && pnpm run build:extension"
+    "build:all": "pnpm run build:webview && pnpm run build:extension",
+    "build:app": "node app/build.js"
   },
   "devDependencies": {
     "concurrently": "^9.2.1",

--- a/scripts/dev-relay.ts
+++ b/scripts/dev-relay.ts
@@ -1,48 +1,22 @@
 #!/usr/bin/env node
 /**
- * Standalone dev relay server for Agent Flow.
- *
- * Replaces the VS Code extension during development by reusing the same
- * core modules (hook-server, session-watcher, transcript-parser, etc.).
- *
- *   1. Starts the HookServer (receives events from hook.js)
- *   2. Starts a lightweight session watcher (tails JSONL transcripts)
- *   3. Writes a discovery file (so hook.js knows where to forward)
- *   4. Relays all events to the browser via SSE
+ * Dev relay server — wraps the shared relay with a standalone HTTP server
+ * that includes CORS headers for cross-origin dev mode (Next.js on :3000).
  */
 import * as http from 'http'
-import * as crypto from 'crypto'
-import * as fs from 'fs'
-import * as path from 'path'
-import * as os from 'os'
+import { createRelay } from './relay'
+import { DEFAULT_RELAY_PORT, DEV_WEB_ORIGIN } from '../extension/src/constants'
 
-// ─── Import from extension source (single source of truth) ──────────────────
+async function main() {
+  const workspace = process.argv[2] || process.cwd()
 
-import { HookServer } from '../extension/src/hook-server'
-import { AgentEvent, SessionInfo, WatchedSession } from '../extension/src/protocol'
-import { TranscriptParser } from '../extension/src/transcript-parser'
-import { readNewFileLines } from '../extension/src/fs-utils'
-import { scanSubagentsDir, readSubagentNewLines } from '../extension/src/subagent-watcher'
-import { handlePermissionDetection } from '../extension/src/permission-detection'
-import {
-  INACTIVITY_TIMEOUT_MS, SCAN_INTERVAL_MS, ACTIVE_SESSION_AGE_S, POLL_FALLBACK_MS,
-  SESSION_ID_DISPLAY, SYSTEM_PROMPT_BASE_TOKENS, ORCHESTRATOR_NAME,
-  HOOK_SERVER_NOT_STARTED, WORKSPACE_HASH_LENGTH,
-} from '../extension/src/constants'
+  console.log('Starting Agent Flow dev relay...\n')
+  console.log(`Workspace: ${workspace}`)
 
-// ─── Config ─────────────────────────────────────────────────────────────────
+  const relay = await createRelay({ workspace, verbose: true })
 
-const SSE_PORT = 3001
-const DISCOVERY_DIR = path.join(os.homedir(), '.claude', 'agent-flow')
-const CLAUDE_DIR = path.join(os.homedir(), '.claude', 'projects')
-
-// ─── SSE relay (Server-Sent Events — plain HTTP) ────────────────────────────
-
-const sseClients = new Set<http.ServerResponse>()
-
-function createSSEServer(port: number) {
   const server = http.createServer((req, res) => {
-    res.setHeader('Access-Control-Allow-Origin', 'http://localhost:3000')
+    res.setHeader('Access-Control-Allow-Origin', DEV_WEB_ORIGIN)
     res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
 
@@ -53,397 +27,25 @@ function createSSEServer(port: number) {
     }
 
     if (req.url === '/events') {
-      res.writeHead(200, {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        'Connection': 'keep-alive',
-      })
-
-      sseClients.add(res)
-      console.log(`[sse] Client connected (${sseClients.size} total)`)
-
-      req.on('close', () => {
-        sseClients.delete(res)
-        console.log(`[sse] Client disconnected (${sseClients.size} total)`)
-      })
-
-      // Send session list (single message, auto-selects once without racing)
-      const sessionList: SessionInfo[] = []
-      for (const session of sessions.values()) {
-        if (!session.sessionDetected) continue
-        sessionList.push({ id: session.sessionId, label: session.label, status: session.sessionCompleted ? 'completed' : 'active', startTime: session.sessionStartTime, lastActivityTime: session.lastActivityTime })
-      }
-      if (sessionList.length > 0) {
-        sendSSE(res, { type: 'session-list', sessions: sessionList })
-      }
-
-      // Replay buffered events for the auto-selected session (most recent active)
-      const sorted = [...sessionList].sort((a, b) => {
-        const aActive = a.status === 'active' ? 1 : 0
-        const bActive = b.status === 'active' ? 1 : 0
-        if (aActive !== bActive) return bActive - aActive
-        return b.lastActivityTime - a.lastActivityTime
-      })
-      if (sorted.length > 0) {
-        const buffered = eventBuffer.get(sorted[0].id)
-        if (buffered) {
-          sendSSE(res, { type: 'agent-event-batch', events: buffered })
-        }
-      }
-      return
+      return relay.handleSSE(req, res)
     }
 
     res.writeHead(200, { 'Content-Type': 'text/plain' })
     res.end('Agent Flow Dev Relay')
   })
 
-  server.listen(port, '127.0.0.1', () => {
-    console.log(`SSE relay on http://127.0.0.1:${port}/events`)
+  server.listen(DEFAULT_RELAY_PORT, '127.0.0.1', () => {
+    console.log(`\nSSE relay on http://127.0.0.1:${DEFAULT_RELAY_PORT}/events`)
+    console.log('Ready! Events will appear in the web app.')
   })
 
-  return server
-}
-
-function sendSSE(res: http.ServerResponse, data: unknown) {
-  try { res.write(`data: ${JSON.stringify(data)}\n\n`) } catch (e) {
-    sseClients.delete(res)
-  }
-}
-
-function broadcast(data: string) {
-  for (const res of sseClients) {
-    try { res.write(`data: ${data}\n\n`) } catch (e) {
-      sseClients.delete(res)
-    }
-  }
-}
-
-// ─── Event buffering & broadcasting ─────────────────────────────────────────
-
-const MAX_EVENT_BUFFER = 5000
-const eventBuffer = new Map<string, AgentEvent[]>()
-
-function broadcastEvent(event: AgentEvent) {
-  const sid = event.sessionId?.slice(0, SESSION_ID_DISPLAY) || '?'
-  console.log(`[event] ${event.type} (session ${sid})`)
-
-  // Buffer events per session for replay on SSE connect
-  if (event.sessionId) {
-    let buf = eventBuffer.get(event.sessionId) || []
-    buf.push(event)
-    if (buf.length > MAX_EVENT_BUFFER) {
-      buf = buf.slice(buf.length - MAX_EVENT_BUFFER)
-    }
-    eventBuffer.set(event.sessionId, buf)
-  }
-
-  broadcast(JSON.stringify({ type: 'agent-event', event }))
-}
-
-function broadcastSessionLifecycle(type: 'started' | 'ended' | 'updated', sessionId: string, label: string) {
-  if (type === 'started') {
-    broadcast(JSON.stringify({
-      type: 'session-started',
-      session: { id: sessionId, label, status: 'active', startTime: Date.now(), lastActivityTime: Date.now() } as SessionInfo,
-    }))
-  } else if (type === 'ended') {
-    broadcast(JSON.stringify({ type: 'session-ended', sessionId }))
-  } else if (type === 'updated') {
-    broadcast(JSON.stringify({ type: 'session-updated', sessionId, label }))
-  }
-}
-
-// ─── Session watcher (reuses TranscriptParser from extension) ───────────────
-
-const sessions = new Map<string, WatchedSession>()
-
-function elapsed(sessionId?: string): number {
-  if (sessionId) {
-    const session = sessions.get(sessionId)
-    if (session) return (Date.now() - session.sessionStartTime) / 1000
-  }
-  return 0
-}
-
-function emitContextUpdate(agentName: string, session: WatchedSession, sessionId?: string) {
-  const bd = session.contextBreakdown
-  const total = bd.systemPrompt + bd.userMessages + bd.toolResults + bd.reasoning + bd.subagentResults
-  broadcastEvent({
-    time: elapsed(sessionId),
-    type: 'context_update',
-    payload: { agent: agentName, tokens: total, breakdown: { ...bd } },
-    sessionId,
-  })
-}
-
-const parser = new TranscriptParser({
-  emit: (event: AgentEvent, sessionId?: string) => broadcastEvent(sessionId ? { ...event, sessionId } : event),
-  elapsed,
-  getSession: (sessionId: string) => sessions.get(sessionId),
-  fireSessionLifecycle: (event) => broadcastSessionLifecycle(event.type, event.sessionId, event.label),
-  emitContextUpdate,
-})
-
-const watcherDelegate = {
-  emit: (event: AgentEvent, sessionId?: string) => broadcastEvent(sessionId ? { ...event, sessionId } : event),
-  elapsed,
-  getSession: (sessionId: string) => sessions.get(sessionId),
-  getLastActivityTime: (sessionId: string) => sessions.get(sessionId)?.lastActivityTime,
-  resetInactivityTimer: (sessionId: string) => resetInactivityTimer(sessionId),
-}
-
-function resetInactivityTimer(sessionId: string) {
-  const session = sessions.get(sessionId)
-  if (!session) return
-
-  const wasCompleted = session.sessionCompleted
-  session.lastActivityTime = Date.now()
-  session.sessionCompleted = false
-
-  if (wasCompleted) {
-    broadcastEvent({
-      time: elapsed(sessionId),
-      type: 'agent_spawn',
-      payload: { name: ORCHESTRATOR_NAME, isMain: true, task: session.label, ...(session.model ? { model: session.model } : {}) },
-      sessionId,
-    })
-    broadcastSessionLifecycle('started', sessionId, session.label)
-  }
-
-  if (session.inactivityTimer) clearTimeout(session.inactivityTimer)
-  session.inactivityTimer = setTimeout(() => {
-    if (!session.sessionCompleted && session.sessionDetected) {
-      console.log(`[session] ${sessionId.slice(0, SESSION_ID_DISPLAY)} inactive — completing`)
-      session.sessionCompleted = true
-      broadcastEvent({
-        time: elapsed(sessionId),
-        type: 'agent_complete',
-        payload: { name: ORCHESTRATOR_NAME },
-        sessionId,
-      })
-      broadcastSessionLifecycle('ended', sessionId, session.label)
-    }
-  }, INACTIVITY_TIMEOUT_MS)
-}
-
-function watchSession(sessionId: string, filePath: string) {
-  const defaultLabel = `Session ${sessionId.slice(0, SESSION_ID_DISPLAY)}`
-  const session: WatchedSession = {
-    sessionId, filePath,
-    fileWatcher: null, pollTimer: null, fileSize: 0,
-    sessionStartTime: Date.now(),
-    pendingToolCalls: new Map(),
-    seenToolUseIds: new Set(),
-    seenMessageHashes: new Set(),
-    sessionDetected: false, sessionCompleted: false,
-    lastActivityTime: Date.now(),
-    inactivityTimer: null,
-    subagentWatchers: new Map(),
-    spawnedSubagents: new Set(),
-    inlineProgressAgents: new Set(),
-    subagentsDirWatcher: null, subagentsDir: null,
-    label: defaultLabel, labelSet: false,
-    model: null,
-    permissionTimer: null, permissionEmitted: false,
-    contextBreakdown: { systemPrompt: SYSTEM_PROMPT_BASE_TOKENS, userMessages: 0, toolResults: 0, reasoning: 0, subagentResults: 0 },
-  }
-  sessions.set(sessionId, session)
-
-  const stat = fs.statSync(filePath)
-  const catchUpEntries = parser.prescanExistingContent(filePath, stat.size, session)
-  session.fileSize = stat.size
-  parser.extractSessionLabel(catchUpEntries, session)
-
-  broadcastSessionLifecycle('started', sessionId, session.label)
-
-  broadcastEvent({
-    time: 0, type: 'agent_spawn',
-    payload: { name: ORCHESTRATOR_NAME, isMain: true, task: session.label, ...(session.model ? { model: session.model } : {}) },
-    sessionId,
-  })
-  session.sessionDetected = true
-
-  emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
-  parser.emitCatchUpEntries(catchUpEntries, session, sessionId)
-
-  session.fileWatcher = fs.watch(filePath, (eventType) => {
-    if (eventType === 'change') readNewLines(sessionId)
-  })
-
-  session.pollTimer = setInterval(() => {
-    readNewLines(sessionId)
-    for (const [subPath] of session.subagentWatchers) {
-      readSubagentNewLines(watcherDelegate, parser, subPath, sessionId)
-    }
-    scanSubagentsDir(watcherDelegate, parser, sessionId)
-  }, POLL_FALLBACK_MS)
-
-  session.subagentsDir = path.join(path.dirname(filePath), sessionId, 'subagents')
-  scanSubagentsDir(watcherDelegate, parser, sessionId)
-  resetInactivityTimer(sessionId)
-
-  console.log(`[session] Watching ${sessionId.slice(0, SESSION_ID_DISPLAY)} — "${session.label}"`)
-}
-
-function readNewLines(sessionId: string) {
-  const session = sessions.get(sessionId)
-  if (!session) return
-
-  const result = readNewFileLines(session.filePath, session.fileSize)
-  if (!result) return
-  session.fileSize = result.newSize
-  for (const line of result.lines) {
-    parser.processTranscriptLine(line, ORCHESTRATOR_NAME, session.pendingToolCalls, session.seenToolUseIds, sessionId, session.seenMessageHashes)
-  }
-
-  handlePermissionDetection(watcherDelegate, ORCHESTRATOR_NAME, session.pendingToolCalls, session, sessionId, session.sessionCompleted, true)
-  scanSubagentsDir(watcherDelegate, parser, sessionId)
-  resetInactivityTimer(sessionId)
-}
-
-// ─── Session scanner ────────────────────────────────────────────────────────
-
-function scanForActiveSessions(workspace: string) {
-  if (!fs.existsSync(CLAUDE_DIR)) return
-
-  let resolved = workspace
-  try { resolved = fs.realpathSync(resolved) } catch {}
-  const encoded = resolved.replace(/[/\\:]/g, '-')
-
-  const dirsToScan: string[] = []
-
-  const projectDir = path.join(CLAUDE_DIR, encoded)
-  if (fs.existsSync(projectDir)) dirsToScan.push(projectDir)
-
-  try {
-    for (const dir of fs.readdirSync(CLAUDE_DIR, { withFileTypes: true })) {
-      if (!dir.isDirectory()) continue
-      const fullPath = path.join(CLAUDE_DIR, dir.name)
-      if (fullPath === projectDir) continue
-      if (dir.name.startsWith(encoded + '-')) {
-        dirsToScan.push(fullPath)
-      }
-    }
-  } catch {}
-
-  for (const dirPath of dirsToScan) {
-    try {
-      for (const file of fs.readdirSync(dirPath)) {
-        if (!file.endsWith('.jsonl')) continue
-        const filePath = path.join(dirPath, file)
-        const stat = fs.statSync(filePath)
-        const sessionId = path.basename(file, '.jsonl')
-
-        let newestMtime = stat.mtimeMs
-        const subagentsDir = path.join(dirPath, sessionId, 'subagents')
-        try {
-          if (fs.existsSync(subagentsDir)) {
-            for (const subFile of fs.readdirSync(subagentsDir)) {
-              if (!subFile.endsWith('.jsonl')) continue
-              const subStat = fs.statSync(path.join(subagentsDir, subFile))
-              if (subStat.mtimeMs > newestMtime) newestMtime = subStat.mtimeMs
-            }
-          }
-        } catch {}
-
-        const ageSeconds = (Date.now() - newestMtime) / 1000
-        if (ageSeconds <= ACTIVE_SESSION_AGE_S && !sessions.has(sessionId)) {
-          watchSession(sessionId, filePath)
-        }
-      }
-    } catch {}
-  }
-}
-
-// ─── Discovery file ─────────────────────────────────────────────────────────
-
-function normalizePath(p: string): string {
-  let resolved = path.resolve(p)
-  try { resolved = fs.realpathSync(resolved) } catch {}
-  return resolved
-}
-
-function hashWorkspace(workspace: string): string {
-  return crypto.createHash('sha256').update(normalizePath(workspace)).digest('hex').slice(0, WORKSPACE_HASH_LENGTH)
-}
-
-let discoveryFilePath: string | null = null
-
-function writeDiscoveryFile(port: number, workspace: string) {
-  if (!fs.existsSync(DISCOVERY_DIR)) fs.mkdirSync(DISCOVERY_DIR, { recursive: true })
-  const hash = hashWorkspace(workspace)
-  discoveryFilePath = path.join(DISCOVERY_DIR, `${hash}-${process.pid}.json`)
-  fs.writeFileSync(discoveryFilePath, JSON.stringify({ port, pid: process.pid, workspace: normalizePath(workspace) }, null, 2) + '\n')
-  console.log(`Discovery file: ${discoveryFilePath}`)
-}
-
-function removeDiscoveryFile() {
-  if (discoveryFilePath) {
-    try { fs.unlinkSync(discoveryFilePath) } catch {}
-  }
-}
-
-// ─── Main ───────────────────────────────────────────────────────────────────
-
-async function main() {
-  const workspace = process.argv[2] || process.cwd()
-
-  console.log('Starting Agent Flow dev relay...\n')
-  console.log(`Workspace: ${workspace}`)
-
-  // Start hook server (reused from extension)
-  const hookServer = new HookServer()
-  const hookPort = await hookServer.start()
-  if (hookPort === HOOK_SERVER_NOT_STARTED) {
-    console.error('Failed to start hook server (port in use)')
-    process.exit(1)
-  }
-
-  // Forward hook events to SSE clients
-  hookServer.onEvent((event: AgentEvent) => {
-    const sid = event.sessionId?.slice(0, SESSION_ID_DISPLAY) || '?'
-    console.log(`[hook] ${event.type} (session ${sid})`)
-    broadcast(JSON.stringify({ type: 'agent-event', event }))
-  })
-
-  // Start SSE relay
-  createSSEServer(SSE_PORT)
-
-  // Write discovery file
-  writeDiscoveryFile(hookPort, workspace)
-
-  // Start session watcher (JSONL transcript tailing)
-  scanForActiveSessions(workspace)
-  setInterval(() => scanForActiveSessions(workspace), SCAN_INTERVAL_MS)
-
-  // Watch for new project directories
-  const resolved = (() => { try { return fs.realpathSync(workspace) } catch { return workspace } })()
-  const encoded = resolved.replace(/[/\\:]/g, '-')
-  const projectDir = path.join(CLAUDE_DIR, encoded)
-  if (fs.existsSync(projectDir)) {
-    try {
-      fs.watch(projectDir, (_eventType, filename) => {
-        if (filename?.endsWith('.jsonl')) scanForActiveSessions(workspace)
-      })
-    } catch {}
-  }
-
-  // Cleanup on exit
   function cleanup() {
-    removeDiscoveryFile()
-    hookServer.dispose()
-    for (const session of sessions.values()) {
-      session.fileWatcher?.close()
-      if (session.pollTimer) clearInterval(session.pollTimer)
-      if (session.inactivityTimer) clearTimeout(session.inactivityTimer)
-    }
+    server.close()
+    relay.dispose()
     process.exit(0)
   }
   process.on('SIGINT', cleanup)
   process.on('SIGTERM', cleanup)
-  process.on('exit', removeDiscoveryFile)
-
-  console.log('\nReady! Claude Code events will appear in the web app.')
 }
 
 main().catch(e => {

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -1,0 +1,424 @@
+/**
+ * Shared relay module — receives agent events and streams them to SSE clients.
+ * Used by both the dev relay server and the standalone app.
+ */
+import * as http from 'http'
+import * as crypto from 'crypto'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+import { HookServer } from '../extension/src/hook-server'
+import { AgentEvent, SessionInfo, WatchedSession } from '../extension/src/protocol'
+import { TranscriptParser } from '../extension/src/transcript-parser'
+import { readNewFileLines } from '../extension/src/fs-utils'
+import { scanSubagentsDir, readSubagentNewLines } from '../extension/src/subagent-watcher'
+import { handlePermissionDetection } from '../extension/src/permission-detection'
+import {
+  INACTIVITY_TIMEOUT_MS, SCAN_INTERVAL_MS, ACTIVE_SESSION_AGE_S, POLL_FALLBACK_MS,
+  SESSION_ID_DISPLAY, SYSTEM_PROMPT_BASE_TOKENS, ORCHESTRATOR_NAME,
+  HOOK_SERVER_NOT_STARTED, WORKSPACE_HASH_LENGTH,
+} from '../extension/src/constants'
+import { setLogLevel } from '../extension/src/logger'
+
+const MAX_EVENT_BUFFER = 5000
+const DISCOVERY_DIR = path.join(os.homedir(), '.claude', 'agent-flow')
+const CLAUDE_DIR = path.join(os.homedir(), '.claude', 'projects')
+
+let relayCreated = false
+let verbose = false
+
+function log(...args: unknown[]) {
+  if (verbose) console.log(...args)
+}
+
+// ─── SSE client management ──────────────────────────────────────────────────
+
+const sseClients = new Set<http.ServerResponse>()
+
+function sendSSE(res: http.ServerResponse, data: unknown) {
+  try { res.write(`data: ${JSON.stringify(data)}\n\n`) } catch {
+    sseClients.delete(res)
+  }
+}
+
+function broadcast(data: string) {
+  for (const res of sseClients) {
+    try { res.write(`data: ${data}\n\n`) } catch {
+      sseClients.delete(res)
+    }
+  }
+}
+
+// ─── Event buffering ────────────────────────────────────────────────────────
+
+const eventBuffer = new Map<string, AgentEvent[]>()
+
+function broadcastEvent(event: AgentEvent) {
+  const sid = event.sessionId?.slice(0, SESSION_ID_DISPLAY) || '?'
+  log(`[event] ${event.type} (session ${sid})`)
+
+  if (event.sessionId) {
+    let buf = eventBuffer.get(event.sessionId) || []
+    buf.push(event)
+    if (buf.length > MAX_EVENT_BUFFER) {
+      buf = buf.slice(buf.length - MAX_EVENT_BUFFER)
+    }
+    eventBuffer.set(event.sessionId, buf)
+  }
+
+  broadcast(JSON.stringify({ type: 'agent-event', event }))
+}
+
+function broadcastSessionLifecycle(type: 'started' | 'ended' | 'updated', sessionId: string, label: string) {
+  if (type === 'started') {
+    broadcast(JSON.stringify({
+      type: 'session-started',
+      session: { id: sessionId, label, status: 'active', startTime: Date.now(), lastActivityTime: Date.now() } as SessionInfo,
+    }))
+  } else if (type === 'ended') {
+    broadcast(JSON.stringify({ type: 'session-ended', sessionId }))
+  } else if (type === 'updated') {
+    broadcast(JSON.stringify({ type: 'session-updated', sessionId, label }))
+  }
+}
+
+// ─── Session watcher ────────────────────────────────────────────────────────
+
+const sessions = new Map<string, WatchedSession>()
+
+function elapsed(sessionId?: string): number {
+  if (sessionId) {
+    const session = sessions.get(sessionId)
+    if (session) return (Date.now() - session.sessionStartTime) / 1000
+  }
+  return 0
+}
+
+function emitContextUpdate(agentName: string, session: WatchedSession, sessionId?: string) {
+  const bd = session.contextBreakdown
+  const total = bd.systemPrompt + bd.userMessages + bd.toolResults + bd.reasoning + bd.subagentResults
+  broadcastEvent({
+    time: elapsed(sessionId),
+    type: 'context_update',
+    payload: { agent: agentName, tokens: total, breakdown: { ...bd } },
+    sessionId,
+  })
+}
+
+function emitEvent(event: AgentEvent, sessionId?: string) {
+  broadcastEvent(sessionId ? { ...event, sessionId } : event)
+}
+
+const parser = new TranscriptParser({
+  emit: emitEvent,
+  elapsed,
+  getSession: (sessionId: string) => sessions.get(sessionId),
+  fireSessionLifecycle: (event) => broadcastSessionLifecycle(event.type, event.sessionId, event.label),
+  emitContextUpdate,
+})
+
+const watcherDelegate = {
+  emit: emitEvent,
+  elapsed,
+  getSession: (sessionId: string) => sessions.get(sessionId),
+  getLastActivityTime: (sessionId: string) => sessions.get(sessionId)?.lastActivityTime,
+  resetInactivityTimer: (sessionId: string) => resetInactivityTimer(sessionId),
+}
+
+function resetInactivityTimer(sessionId: string) {
+  const session = sessions.get(sessionId)
+  if (!session) return
+
+  const wasCompleted = session.sessionCompleted
+  session.lastActivityTime = Date.now()
+  session.sessionCompleted = false
+
+  if (wasCompleted) {
+    broadcastEvent({
+      time: elapsed(sessionId),
+      type: 'agent_spawn',
+      payload: { name: ORCHESTRATOR_NAME, isMain: true, task: session.label, ...(session.model ? { model: session.model } : {}) },
+      sessionId,
+    })
+    broadcastSessionLifecycle('started', sessionId, session.label)
+  }
+
+  if (session.inactivityTimer) clearTimeout(session.inactivityTimer)
+  session.inactivityTimer = setTimeout(() => {
+    if (!session.sessionCompleted && session.sessionDetected) {
+      log(`[session] ${sessionId.slice(0, SESSION_ID_DISPLAY)} inactive`)
+      session.sessionCompleted = true
+      broadcastEvent({
+        time: elapsed(sessionId),
+        type: 'agent_complete',
+        payload: { name: ORCHESTRATOR_NAME },
+        sessionId,
+      })
+      broadcastSessionLifecycle('ended', sessionId, session.label)
+    }
+  }, INACTIVITY_TIMEOUT_MS)
+}
+
+function watchSession(sessionId: string, filePath: string) {
+  const defaultLabel = `Session ${sessionId.slice(0, SESSION_ID_DISPLAY)}`
+  const session: WatchedSession = {
+    sessionId, filePath,
+    fileWatcher: null, pollTimer: null, fileSize: 0,
+    sessionStartTime: Date.now(),
+    pendingToolCalls: new Map(),
+    seenToolUseIds: new Set(),
+    seenMessageHashes: new Set(),
+    sessionDetected: false, sessionCompleted: false,
+    lastActivityTime: Date.now(),
+    inactivityTimer: null,
+    subagentWatchers: new Map(),
+    spawnedSubagents: new Set(),
+    inlineProgressAgents: new Set(),
+    subagentsDirWatcher: null, subagentsDir: null,
+    label: defaultLabel, labelSet: false,
+    model: null,
+    permissionTimer: null, permissionEmitted: false,
+    contextBreakdown: { systemPrompt: SYSTEM_PROMPT_BASE_TOKENS, userMessages: 0, toolResults: 0, reasoning: 0, subagentResults: 0 },
+  }
+  sessions.set(sessionId, session)
+
+  const stat = fs.statSync(filePath)
+  const catchUpEntries = parser.prescanExistingContent(filePath, stat.size, session)
+  session.fileSize = stat.size
+  parser.extractSessionLabel(catchUpEntries, session)
+
+  broadcastSessionLifecycle('started', sessionId, session.label)
+  broadcastEvent({
+    time: 0, type: 'agent_spawn',
+    payload: { name: ORCHESTRATOR_NAME, isMain: true, task: session.label, ...(session.model ? { model: session.model } : {}) },
+    sessionId,
+  })
+  session.sessionDetected = true
+
+  emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
+  parser.emitCatchUpEntries(catchUpEntries, session, sessionId)
+
+  session.fileWatcher = fs.watch(filePath, (eventType) => {
+    if (eventType === 'change') readNewLines(sessionId)
+  })
+
+  session.pollTimer = setInterval(() => {
+    readNewLines(sessionId)
+    for (const [subPath] of session.subagentWatchers) {
+      readSubagentNewLines(watcherDelegate, parser, subPath, sessionId)
+    }
+    scanSubagentsDir(watcherDelegate, parser, sessionId)
+  }, POLL_FALLBACK_MS)
+
+  session.subagentsDir = path.join(path.dirname(filePath), sessionId, 'subagents')
+  scanSubagentsDir(watcherDelegate, parser, sessionId)
+  resetInactivityTimer(sessionId)
+
+  log(`[session] Watching ${sessionId.slice(0, SESSION_ID_DISPLAY)} — "${session.label}"`)
+}
+
+function readNewLines(sessionId: string) {
+  const session = sessions.get(sessionId)
+  if (!session) return
+
+  const result = readNewFileLines(session.filePath, session.fileSize)
+  if (!result) return
+  session.fileSize = result.newSize
+  for (const line of result.lines) {
+    parser.processTranscriptLine(line, ORCHESTRATOR_NAME, session.pendingToolCalls, session.seenToolUseIds, sessionId, session.seenMessageHashes)
+  }
+
+  handlePermissionDetection(watcherDelegate, ORCHESTRATOR_NAME, session.pendingToolCalls, session, sessionId, session.sessionCompleted, true)
+  scanSubagentsDir(watcherDelegate, parser, sessionId)
+  resetInactivityTimer(sessionId)
+}
+
+// ─── Session scanner ────────────────────────────────────────────────────────
+
+function scanForActiveSessions(workspace: string) {
+  if (!fs.existsSync(CLAUDE_DIR)) return
+
+  let resolved = workspace
+  try { resolved = fs.realpathSync(resolved) } catch {}
+  const encoded = resolved.replace(/[/\\:]/g, '-')
+
+  const dirsToScan: string[] = []
+  const projectDir = path.join(CLAUDE_DIR, encoded)
+  if (fs.existsSync(projectDir)) dirsToScan.push(projectDir)
+
+  try {
+    for (const dir of fs.readdirSync(CLAUDE_DIR, { withFileTypes: true })) {
+      if (!dir.isDirectory()) continue
+      const fullPath = path.join(CLAUDE_DIR, dir.name)
+      if (fullPath === projectDir) continue
+      if (dir.name.startsWith(encoded + '-')) {
+        dirsToScan.push(fullPath)
+      }
+    }
+  } catch {}
+
+  for (const dirPath of dirsToScan) {
+    try {
+      for (const file of fs.readdirSync(dirPath)) {
+        if (!file.endsWith('.jsonl')) continue
+        const filePath = path.join(dirPath, file)
+        const stat = fs.statSync(filePath)
+        const sessionId = path.basename(file, '.jsonl')
+
+        let newestMtime = stat.mtimeMs
+        const subagentsDir = path.join(dirPath, sessionId, 'subagents')
+        try {
+          if (fs.existsSync(subagentsDir)) {
+            for (const subFile of fs.readdirSync(subagentsDir)) {
+              if (!subFile.endsWith('.jsonl')) continue
+              const subStat = fs.statSync(path.join(subagentsDir, subFile))
+              if (subStat.mtimeMs > newestMtime) newestMtime = subStat.mtimeMs
+            }
+          }
+        } catch {}
+
+        const ageSeconds = (Date.now() - newestMtime) / 1000
+        if (ageSeconds <= ACTIVE_SESSION_AGE_S && !sessions.has(sessionId)) {
+          watchSession(sessionId, filePath)
+        }
+      }
+    } catch {}
+  }
+}
+
+// ─── Discovery file ─────────────────────────────────────────────────────────
+
+function normalizePath(p: string): string {
+  let resolved = path.resolve(p)
+  try { resolved = fs.realpathSync(resolved) } catch {}
+  return resolved
+}
+
+function hashWorkspace(workspace: string): string {
+  return crypto.createHash('sha256').update(normalizePath(workspace)).digest('hex').slice(0, WORKSPACE_HASH_LENGTH)
+}
+
+let discoveryFilePath: string | null = null
+
+function writeDiscoveryFile(port: number, workspace: string) {
+  if (!fs.existsSync(DISCOVERY_DIR)) fs.mkdirSync(DISCOVERY_DIR, { recursive: true })
+  const hash = hashWorkspace(workspace)
+  discoveryFilePath = path.join(DISCOVERY_DIR, `${hash}-${process.pid}.json`)
+  fs.writeFileSync(discoveryFilePath, JSON.stringify({ port, pid: process.pid, workspace: normalizePath(workspace) }, null, 2) + '\n')
+}
+
+function removeDiscoveryFile() {
+  if (discoveryFilePath) {
+    try { fs.unlinkSync(discoveryFilePath) } catch {}
+  }
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+export interface Relay {
+  /** Handle an incoming SSE connection */
+  handleSSE: (req: http.IncomingMessage, res: http.ServerResponse) => void
+  /** Clean up all resources */
+  dispose: () => void
+}
+
+export interface RelayOptions {
+  workspace: string
+  verbose?: boolean
+}
+
+export async function createRelay(options: RelayOptions): Promise<Relay> {
+  const { workspace } = options
+  verbose = options.verbose ?? false
+  if (!verbose) setLogLevel('error')
+  if (relayCreated) {
+    throw new Error('createRelay() can only be called once per process')
+  }
+  relayCreated = true
+
+  const hookServer = new HookServer()
+  const hookPort = await hookServer.start()
+  if (hookPort === HOOK_SERVER_NOT_STARTED) {
+    throw new Error('Failed to start hook server (port in use)')
+  }
+
+  hookServer.onEvent((event: AgentEvent) => {
+    broadcast(JSON.stringify({ type: 'agent-event', event }))
+  })
+
+  writeDiscoveryFile(hookPort, workspace)
+
+  scanForActiveSessions(workspace)
+  const scanInterval = setInterval(() => scanForActiveSessions(workspace), SCAN_INTERVAL_MS)
+
+  const resolved = (() => { try { return fs.realpathSync(workspace) } catch { return workspace } })()
+  const encoded = resolved.replace(/[/\\:]/g, '-')
+  const projectDir = path.join(CLAUDE_DIR, encoded)
+  let projectDirWatcher: fs.FSWatcher | null = null
+  if (fs.existsSync(projectDir)) {
+    try {
+      projectDirWatcher = fs.watch(projectDir, (_eventType, filename) => {
+        if (filename?.endsWith('.jsonl')) scanForActiveSessions(workspace)
+      })
+    } catch {}
+  }
+
+  return {
+    handleSSE(req: http.IncomingMessage, res: http.ServerResponse) {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      })
+
+      sseClients.add(res)
+      log(`[sse] Client connected (${sseClients.size} total)`)
+
+      req.on('close', () => {
+        sseClients.delete(res)
+        log(`[sse] Client disconnected (${sseClients.size} total)`)
+      })
+
+      // Send current session list
+      const sessionList: SessionInfo[] = []
+      for (const session of sessions.values()) {
+        if (!session.sessionDetected) continue
+        sessionList.push({
+          id: session.sessionId, label: session.label,
+          status: session.sessionCompleted ? 'completed' : 'active',
+          startTime: session.sessionStartTime, lastActivityTime: session.lastActivityTime,
+        })
+      }
+      if (sessionList.length > 0) {
+        sendSSE(res, { type: 'session-list', sessions: sessionList })
+      }
+
+      // Replay buffered events for the most recent active session
+      const sorted = [...sessionList].sort((a, b) => {
+        const aActive = a.status === 'active' ? 1 : 0
+        const bActive = b.status === 'active' ? 1 : 0
+        if (aActive !== bActive) return bActive - aActive
+        return b.lastActivityTime - a.lastActivityTime
+      })
+      if (sorted.length > 0) {
+        const buffered = eventBuffer.get(sorted[0].id)
+        if (buffered) {
+          sendSSE(res, { type: 'agent-event-batch', events: buffered })
+        }
+      }
+    },
+
+    dispose() {
+      removeDiscoveryFile()
+      hookServer.dispose()
+      clearInterval(scanInterval)
+      projectDirWatcher?.close()
+      for (const session of sessions.values()) {
+        session.fileWatcher?.close()
+        if (session.pollTimer) clearInterval(session.pollTimer)
+        if (session.inactivityTimer) clearTimeout(session.inactivityTimer)
+      }
+    },
+  }
+}

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -216,14 +216,28 @@ function isAlreadySetup() {
 
 // ─── Main ───────────────────────────────────────────────────────────────────
 
-const force = process.argv.includes('--force')
-
-if (!force && isAlreadySetup()) {
-  console.log('Agent Flow is already set up. Run with --force to reconfigure.')
-  process.exit(0)
+/** Ensure hooks are configured, skip silently if already set up. */
+function ensureSetup() {
+  if (isAlreadySetup()) return
+  console.log('Setting up agent hooks...')
+  ensureHookScript()
+  configureHooks()
+  console.log('')
 }
 
-console.log('Setting up Agent Flow...\n')
-ensureHookScript()
-configureHooks()
-console.log('\nDone! New Claude Code sessions will stream events to Agent Flow.')
+module.exports = { ensureSetup }
+
+// Run directly: node scripts/setup.js [--force]
+if (require.main === module) {
+  const force = process.argv.includes('--force')
+
+  if (!force && isAlreadySetup()) {
+    console.log('Agent Flow is already set up. Run with --force to reconfigure.')
+    process.exit(0)
+  }
+
+  console.log('Setting up Agent Flow...\n')
+  ensureHookScript()
+  configureHooks()
+  console.log('\nDone! New sessions will stream events to Agent Flow.')
+}

--- a/web/app-entry.tsx
+++ b/web/app-entry.tsx
@@ -1,0 +1,9 @@
+import { createRoot } from 'react-dom/client'
+import { AgentVisualizer } from './components/agent-visualizer'
+import './app/globals.css'
+
+// Standalone CLI entry — no VS Code API, connects to relay via SSE
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Root element #root not found')
+const root = createRoot(rootElement)
+root.render(<AgentVisualizer />)

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -69,11 +69,12 @@ export function useVSCodeBridge(): BridgeHookResult {
     // Skip in VS Code — extension handles events via postMessage
     if (bridge.isVSCode) return
 
-    // Only connect in development mode without demo
-    if (process.env.NODE_ENV !== 'development' || process.env.NEXT_PUBLIC_DEMO !== '0') return
+    // Connect to relay in dev mode or standalone CLI mode
+    const isStandalone = process.env.AGENT_FLOW_STANDALONE === '1'
+    if (!isStandalone && (process.env.NODE_ENV !== 'development' || process.env.NEXT_PUBLIC_DEMO !== '0')) return
 
-    const relayPort = process.env.NEXT_PUBLIC_RELAY_PORT || '3001'
-    const es = new EventSource(`http://127.0.0.1:${relayPort}/events`)
+    const relayPort = process.env.NEXT_PUBLIC_RELAY_PORT || ''
+    const es = new EventSource(relayPort ? `http://127.0.0.1:${relayPort}/events` : '/events')
 
     es.onopen = () => {
       setConnectionStatus('connected')

--- a/web/vite.config.app.ts
+++ b/web/vite.config.app.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import { createBuildConfig } from './vite.config.shared'
+
+export default defineConfig(createBuildConfig({
+  outDir: '../app/dist/webview',
+  entry: 'app-entry.tsx',
+  name: 'AgentFlowApp',
+  define: {
+    'process.env.NEXT_PUBLIC_DEMO': '"0"',
+    'process.env.NEXT_PUBLIC_RELAY_PORT': '""',
+    'process.env.AGENT_FLOW_STANDALONE': '"1"',
+  },
+}))

--- a/web/vite.config.shared.ts
+++ b/web/vite.config.shared.ts
@@ -1,0 +1,53 @@
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { resolve } from 'path'
+import type { UserConfig } from 'vite'
+
+interface BuildTarget {
+  outDir: string
+  entry: string
+  name: string
+  define: Record<string, string>
+}
+
+export function createBuildConfig(target: BuildTarget): UserConfig {
+  return {
+    plugins: [
+      react(),
+      tailwindcss(),
+    ],
+    resolve: {
+      alias: {
+        '@': resolve(__dirname),
+      },
+    },
+    publicDir: false,
+    build: {
+      outDir: resolve(__dirname, target.outDir),
+      emptyOutDir: true,
+      lib: {
+        entry: resolve(__dirname, target.entry),
+        formats: ['iife'],
+        name: target.name,
+        fileName: () => 'index',
+      },
+      // @ts-expect-error — cssFileName is valid in Vite 8 but not yet in @types
+      cssFileName: 'index',
+      sourcemap: false,
+      minify: true,
+      rollupOptions: {
+        output: {
+          entryFileNames: 'index.js',
+          assetFileNames: (info: { names?: string[] }) => {
+            if (info.names?.[0]?.endsWith('.css')) return 'index.css'
+            return '[name].[ext]'
+          },
+        },
+      },
+    },
+    define: {
+      'process.env.NODE_ENV': '"production"',
+      ...target.define,
+    },
+  }
+}

--- a/web/vite.config.webview.ts
+++ b/web/vite.config.webview.ts
@@ -1,45 +1,14 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-import { resolve } from 'path'
+import { createBuildConfig } from './vite.config.shared'
+import { DEFAULT_RELAY_PORT } from '../extension/src/constants'
 
-export default defineConfig({
-  plugins: [
-    react(),
-    tailwindcss(),
-  ],
-  resolve: {
-    alias: {
-      '@': resolve(__dirname),
-    },
-  },
-  publicDir: false,
-  build: {
-    outDir: resolve(__dirname, '../extension/dist/webview'),
-    emptyOutDir: true,
-    lib: {
-      entry: resolve(__dirname, 'webview-entry.tsx'),
-      formats: ['iife'],
-      name: 'AgentFlowWebview',
-      fileName: () => 'index',
-    },
-    // @ts-expect-error — cssFileName is valid in Vite 8 but not yet in @types
-    cssFileName: 'index',
-    sourcemap: false,
-    minify: true,
-    rollupOptions: {
-      output: {
-        entryFileNames: 'index.js',
-        assetFileNames: (info) => {
-          if (info.names?.[0]?.endsWith('.css')) return 'index.css'
-          return '[name].[ext]'
-        },
-      },
-    },
-  },
+export default defineConfig(createBuildConfig({
+  outDir: '../extension/dist/webview',
+  entry: 'webview-entry.tsx',
+  name: 'AgentFlowWebview',
   define: {
-    'process.env.NODE_ENV': '"production"',
     'process.env.NEXT_PUBLIC_DEMO': '"1"',
-    'process.env.NEXT_PUBLIC_RELAY_PORT': '"3001"',
+    'process.env.NEXT_PUBLIC_RELAY_PORT': JSON.stringify(String(DEFAULT_RELAY_PORT)),
+    'process.env.AGENT_FLOW_STANDALONE': '"0"',
   },
-})
+}))


### PR DESCRIPTION
## What does this PR do?

Adds a standalone web app that can be run via `npx agent-flow-app` -- no VS Code or repo clone required. Closes #23.

- Standalone app package (`app/`) that bundles the relay server + pre-built UI into a single npm package
- Shared relay module (`scripts/relay.ts`) used by both the dev server and the standalone app -- no duplicated logic
- Shared Vite build config (`web/vite.config.shared.ts`) for webview and app builds
- Quiet output by default, `--verbose` flag for detailed logs
- `setLogLevel` export in extension logger for controlling verbosity
- Centralized constants for relay port and dev origin
- Updated README with npx quickstart instructions

## How to test

1. `npx agent-flow-app --help` -- verify help output
2. `npx agent-flow-app --no-open` -- verify server starts quietly on http://127.0.0.1:3001
3. `npx agent-flow-app --no-open --verbose` -- verify detailed logs appear
4. Open http://127.0.0.1:3001 in browser -- verify UI loads
5. Start a Claude Code session in another terminal -- verify events stream in real-time
6. `pnpm run build:all` -- verify extension build still works
7. `pnpm run dev` -- verify dev relay still works

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)