### PR TITLE
Fix fallback path encoding to match primary regex

### DIFF
--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -142,7 +142,7 @@ export class SessionWatcher implements vscode.Disposable {
       if (fs.existsSync(resolvedDir)) {
         this.workspacePath = encoded
       } else {
-        const unresolvedEncoded = workspaceFolder.replace(/[/\\:_]/g, '-')
+        const unresolvedEncoded = workspaceFolder.replace(/[^a-zA-Z0-9]/g, '-')
         const unresolvedDir = path.join(CLAUDE_DIR, unresolvedEncoded)
         this.workspacePath = fs.existsSync(unresolvedDir) ? unresolvedEncoded : encoded
       }


### PR DESCRIPTION
## What does this PR do?

Follow-up to #19 — the fallback path encoding regex (`[/\\:_]`) was not updated to match the primary regex (`[^a-zA-Z0-9]`). This inconsistency meant the fallback branch could still fail to detect sessions for paths containing spaces, dots, or other non-alphanumeric characters.

## How to test

1. Open a workspace whose path contains special characters (e.g. `~/my.projects/some_folder`)
2. Ensure the resolved symlink path does **not** match a `~/.claude/projects/` directory (to trigger the fallback branch)
3. Start a Claude Code session and verify Agent Flow detects it

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)