### PR TITLE
Fix web app SSE connection failure in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.js",
-    "dev": "NEXT_PUBLIC_DEMO=0 concurrently -n relay,web -c blue,green \"pnpm run dev:relay\" \"pnpm run dev:web\"",
+    "dev": "NEXT_PUBLIC_DEMO=0 NEXT_PUBLIC_RELAY_PORT=3001 concurrently -n relay,web -c blue,green \"pnpm run dev:relay\" \"pnpm run dev:web\"",
     "dev:relay": "node scripts/build-relay.js && node scripts/.dev-relay.js",
     "dev:demo": "NEXT_PUBLIC_DEMO=1 pnpm run dev:web",
     "dev:web": "pnpm --filter agent-flow-web run dev",


### PR DESCRIPTION
## What does this PR do?

Sets `NEXT_PUBLIC_RELAY_PORT=3001` in the `dev` script so the web app connects to the relay's SSE endpoint instead of a non-existent `/events` route on the Next.js server. The webview Vite config already sets this variable correctly; the Next.js dev path was missed.

Closes #29

## How to test

1. Run `pnpm run dev`
2. Start a Claude Code session in another terminal
3. Open `http://localhost:3000` and verify events stream to the web app
4. Verify `npx agent-flow-app` still works (unaffected — uses its own server)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)