### PR TITLE
Fix duplicate React key warning on session switch

### DIFF
--- a/web/hooks/simulation/types.ts
+++ b/web/hooks/simulation/types.ts
@@ -51,7 +51,7 @@ export function createEmptyState(overrides?: Partial<SimulationState>): Simulati
 
 let _msgIdCounter = 0
 export function nextMsgId(): string { return `msg-${_msgIdCounter++}` }
-export function resetMsgIdCounter(): void { _msgIdCounter = 0 }
+export function resetMsgIdCounter(): void { /* noop — keep counter monotonic to avoid duplicate React keys */ }
 
 export interface ConversationMessage {
   id: string


### PR DESCRIPTION
## What does this PR do?

Prevents `resetMsgIdCounter()` from resetting the global message ID counter to 0 on session switch. Previously, rendered messages from the prior session could still hold IDs like `msg-0`, and new messages for the incoming session received the same IDs, causing React key collisions in the chat panel.

The counter now stays monotonically increasing to guarantee unique keys.

Closes #30

## How to test

1. Run Agent Flow and connect to two or more active Claude Code sessions
2. Open the chat panel for one session
3. Switch between sessions repeatedly
4. Check the browser console — no "two children with the same key" warnings should appear

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)