### PR TITLE
Fix duplicate subagent nodes from hook server and transcript parser race

### DIFF
--- a/extension/src/hook-server.ts
+++ b/extension/src/hook-server.ts
@@ -255,18 +255,18 @@ export class HookServer implements vscode.Disposable {
   }
 
   private handleSubagentStart(payload: HookPayload): void {
-    const parentName = this.resolveAgentName(payload)
+    // Track agent_id → name mapping for SubagentStop resolution, but do not
+    // emit agent_spawn here.  The transcript parser independently spawns the
+    // subagent using its description field (via resolveSubagentChildName),
+    // which produces the user-facing name.  Emitting a second spawn from the
+    // hook creates a duplicate node with a generic name like
+    // "general-purpose-ab75a" alongside the correctly-named node.
     const agentType = payload.agent_type || 'subagent'
     const agentId = payload.agent_id || ''
     const sessionAgents = this.getOrCreateSession(payload.session_id).agentNames
     const childName = agentId ? `${agentType}-${agentId.slice(-SUBAGENT_ID_SUFFIX_LENGTH)}` : generateSubagentFallbackName(String(Date.now()), sessionAgents.size + 1)
 
     sessionAgents.set(agentId, childName)
-
-    emitSubagentSpawn(
-      { emit: (e, s) => this.emit(e, s), elapsed: (s) => this.elapsedSeconds(s) },
-      parentName, childName, agentType, payload.session_id,
-    )
   }
 
   private handleSubagentStop(payload: HookPayload): void {


### PR DESCRIPTION
## What does this PR do?

Removes the redundant `emitSubagentSpawn` call from the hook server's `handleSubagentStart`. The hook server constructed a generic name from `agent_type` and `agent_id` (e.g. `general-purpose-ab75a`), while the transcript parser independently spawned the same subagent using the `description` field — the correct user-facing name. Both paths emitting `agent_spawn` created two visible nodes on the canvas for one subagent.

The hook server now only tracks the `agent_id`→name mapping needed for `SubagentStop` resolution, without emitting a duplicate spawn.

Closes #31

## How to test

1. Run Agent Flow and connect to a Claude Code session
2. Spawn subagents via the Agent tool (e.g. with `subagent_type: "general-purpose"` and a `description`)
3. Verify only one node per subagent appears on the canvas
4. Verify subagent completion still works (node transitions to complete state)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)