### PR TITLE
Fix path encoding in relay.ts to match Claude Code's non-ASCII handling

### DIFF
--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -241,7 +241,7 @@ function scanForActiveSessions(workspace: string) {
 
   let resolved = workspace
   try { resolved = fs.realpathSync(resolved) } catch {}
-  const encoded = resolved.replace(/[/\\:]/g, '-')
+  const encoded = resolved.replace(/[^a-zA-Z0-9]/g, '-')
 
   const dirsToScan: string[] = []
   const projectDir = path.join(CLAUDE_DIR, encoded)
@@ -353,7 +353,7 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
   const scanInterval = setInterval(() => scanForActiveSessions(workspace), SCAN_INTERVAL_MS)
 
   const resolved = (() => { try { return fs.realpathSync(workspace) } catch { return workspace } })()
-  const encoded = resolved.replace(/[/\\:]/g, '-')
+  const encoded = resolved.replace(/[^a-zA-Z0-9]/g, '-')
   const projectDir = path.join(CLAUDE_DIR, encoded)
   let projectDirWatcher: fs.FSWatcher | null = null
   if (fs.existsSync(projectDir)) {


### PR DESCRIPTION
## Summary

- Fix `scripts/relay.ts` path encoding regex to match Claude Code's algorithm (`/[^a-zA-Z0-9]/g` instead of `/[/\:]/g`)
- This fixes session detection failure when workspace paths contain non-ASCII characters (CJK, Cyrillic, accented Latin, etc.) or dots

## Problem

Claude Code encodes project paths under `~/.claude/projects/<encoded-path>/` by replacing **all non-alphanumeric characters** with dashes:

```
D:\00.개인\블로거  →  D--00-----------
```

But `relay.ts` only replaced path separators and colons:

```
D:\00.개인\블로거  →  D-00.개인-블로거
```

This mismatch meant `scanForActiveSessions()` and `createRelay()` could never find the JSONL transcript directory, so no sessions were detected.

> **Note**: A similar fix was applied to `app.js` in #19 (commit 6250f02), but the source file `scripts/relay.ts` was not updated.

## Changes

- `scripts/relay.ts` line 244 (`scanForActiveSessions`): `/[/\:]/g` → `/[^a-zA-Z0-9]/g`
- `scripts/relay.ts` line 356 (`createRelay`): `/[/\:]/g` → `/[^a-zA-Z0-9]/g`

## Test plan

- [ ] Verify session detection works with non-ASCII workspace paths (e.g., `D:\00.개인\블로거`)
- [ ] Verify session detection still works with ASCII-only paths
- [ ] Verify file watcher in `createRelay` connects to the correct directory