### PR TITLE
Respect CLAUDE_CODE_DISABLE_1M_CONTEXT env var in context gauge

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -11,6 +11,7 @@ import {
 import {
   promptHookSetupIfNeeded,
   configureClaudeHooks, migrateHttpHooks,
+  isDisable1MContext,
 } from './hooks-config'
 import {
   writeDiscoveryFile, removeDiscoveryFile,
@@ -241,6 +242,10 @@ function wirePanel(panel: VisualizerPanel): void {
         panel.markReady()
         // Clear stale webview state from any previous panel instance
         panel.postMessage({ type: 'reset', reason: 'panel-reopened' })
+        // Send environment-derived config (e.g. CLAUDE_CODE_DISABLE_1M_CONTEXT)
+        if (isDisable1MContext()) {
+          panel.postMessage({ type: 'config', config: { disable1MContext: true } })
+        }
         // Report current connection status and replay active sessions
         if (sessionWatcher) {
           // Send session list FIRST so the webview selects a session

--- a/extension/src/hooks-config.ts
+++ b/extension/src/hooks-config.ts
@@ -13,6 +13,19 @@ import { createLogger } from './logger'
 
 const log = createLogger('Hooks')
 
+const GLOBAL_SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json')
+
+/** Read and parse Claude Code's global settings.json. Returns null on failure. */
+function readGlobalSettings(): Record<string, unknown> | null {
+  try {
+    if (!fs.existsSync(GLOBAL_SETTINGS_PATH)) { return null }
+    return JSON.parse(fs.readFileSync(GLOBAL_SETTINGS_PATH, 'utf-8'))
+  } catch (err) {
+    log.debug('Failed to read Claude settings:', err)
+    return null
+  }
+}
+
 /** Check whether a single hook entry belongs to Agent Flow */
 function isAgentFlowHook(entry: ClaudeHookEntry): boolean {
   return !!entry.hooks?.some(h =>
@@ -24,8 +37,7 @@ function isAgentFlowHook(entry: ClaudeHookEntry): boolean {
 // ─── Detection ────────────────────────────────────────────────────────────────
 
 function hooksAlreadyConfigured(): boolean {
-  const globalPath = path.join(os.homedir(), '.claude', 'settings.json')
-  if (hasAgentFlowHooks(globalPath)) { return true }
+  if (hasAgentFlowHooks(GLOBAL_SETTINGS_PATH)) { return true }
 
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
   if (workspaceFolder) {
@@ -76,17 +88,8 @@ export async function configureClaudeHooks(): Promise<void> {
     SessionEnd: [hookEntry],
   }
 
-  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
-
   // Read existing settings
-  let settings: Record<string, unknown> = {}
-  try {
-    if (fs.existsSync(settingsPath)) {
-      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'))
-    }
-  } catch (err) {
-    log.debug('Could not read existing settings, starting fresh:', err)
-  }
+  let settings: Record<string, unknown> = readGlobalSettings() ?? {}
 
   // Merge hooks — preserve existing hooks, replace ours
   const existingHooks = (settings.hooks || {}) as Record<string, unknown[]>
@@ -100,11 +103,11 @@ export async function configureClaudeHooks(): Promise<void> {
   settings.hooks = existingHooks
 
   // Write
-  const dir = path.dirname(settingsPath)
+  const dir = path.dirname(GLOBAL_SETTINGS_PATH)
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true })
   }
-  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n')
+  fs.writeFileSync(GLOBAL_SETTINGS_PATH, JSON.stringify(settings, null, 2) + '\n')
 
   vscode.window.showInformationMessage(
     'Claude Code hooks configured. New sessions will stream events to Agent Flow.',
@@ -116,9 +119,7 @@ export async function configureClaudeHooks(): Promise<void> {
 /** Replace legacy HTTP hooks with command hooks. Called once on activation.
  *  Caller must call ensureHookScript() first. */
 export function migrateHttpHooks(): void {
-  const pathsToCheck: string[] = [
-    path.join(os.homedir(), '.claude', 'settings.json'),
-  ]
+  const pathsToCheck: string[] = [GLOBAL_SETTINGS_PATH]
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
   if (workspaceFolder) {
     pathsToCheck.push(path.join(workspaceFolder, '.claude', 'settings.local.json'))
@@ -165,6 +166,15 @@ export function migrateHttpHooks(): void {
       log.error(`Failed to migrate ${settingsPath}:`, err)
     }
   }
+}
+
+// ─── Claude Code Environment ─────────────────────────────────────────────────
+
+/** Check whether CLAUDE_CODE_DISABLE_1M_CONTEXT is set (via env or Claude Code settings). */
+export function isDisable1MContext(): boolean {
+  if (process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT === '1') { return true }
+  const settings = readGlobalSettings()
+  return (settings?.env as Record<string, unknown>)?.CLAUDE_CODE_DISABLE_1M_CONTEXT === '1'
 }
 
 // ─── Prompt ───────────────────────────────────────────────────────────────────

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -43,7 +43,7 @@ export type ExtensionToWebviewMessage =
   | { type: 'agent-event'; event: AgentEvent }
   | { type: 'agent-event-batch'; events: AgentEvent[] }
   | { type: 'reset'; reason: string }
-  | { type: 'config'; config: VisualizerConfig }
+  | { type: 'config'; config: Partial<VisualizerConfig> }
   | { type: 'session-list'; sessions: SessionInfo[] }
   | { type: 'session-started'; session: SessionInfo }
   | { type: 'session-ended'; sessionId: string }
@@ -53,6 +53,7 @@ export interface VisualizerConfig {
   mode: 'live' | 'replay'
   autoPlay: boolean
   showMockData: boolean
+  disable1MContext: boolean
 }
 
 // ─── Webview → Extension Messages ────────────────────────────────────────────

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -58,6 +58,7 @@ export function AgentVisualizer() {
     // Pass the ref that's updated synchronously in session-started handler,
     // so the animation frame never uses a stale filter value.
     sessionFilterRef: bridge.selectedSessionIdRef,
+    disable1MContext: bridge.disable1MContext,
   })
 
   const selection = useSelectionState({ agents, toolCalls, discoveries })

--- a/web/hooks/simulation/types.ts
+++ b/web/hooks/simulation/types.ts
@@ -122,4 +122,6 @@ export interface UseAgentSimulationOptions {
   sessionFilter?: string | null
   /** Ref updated synchronously when session changes (avoids stale closure in rAF) */
   sessionFilterRef?: React.RefObject<string | null>
+  /** If true, CLAUDE_CODE_DISABLE_1M_CONTEXT is set — cap context window to 200k */
+  disable1MContext?: boolean
 }

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -22,7 +22,7 @@ import { snapVisualState } from './simulation/snap-visual-state'
 const UI_THROTTLE_MS = 250
 
 export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
-  const { useMockData = true, externalEvents, onExternalEventsConsumed, sessionFilter, sessionFilterRef: externalFilterRef } = options
+  const { useMockData = true, externalEvents, onExternalEventsConsumed, sessionFilter, sessionFilterRef: externalFilterRef, disable1MContext = false } = options
   const internalFilterRef = useRef(sessionFilter)
   internalFilterRef.current = sessionFilter
   const sessionFilterRef = externalFilterRef ?? internalFilterRef
@@ -151,13 +151,13 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
   }, [])
 
   const getContextWindowSize = useCallback((modelId?: string): number => {
-    if (!modelId) return FALLBACK_CONTEXT_SIZE
+    if (!modelId) return disable1MContext ? DEFAULT_CONTEXT_SIZE : FALLBACK_CONTEXT_SIZE
     const id = modelId.toLowerCase()
     for (const [key, size] of Object.entries(MODEL_CONTEXT_SIZES)) {
-      if (id.includes(key)) return size
+      if (id.includes(key)) return disable1MContext ? Math.min(size, DEFAULT_CONTEXT_SIZE) : size
     }
     return DEFAULT_CONTEXT_SIZE
-  }, [])
+  }, [disable1MContext])
 
   const processEventWithContext = useCallback((event: SimulationEvent, prev: SimulationState): SimulationState => {
     const ctx: ProcessEventContext = {

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -13,6 +13,8 @@ interface BridgeHookResult {
   consumeEvents: () => void
   /** Whether to show mock data (standalone mode or explicit config) */
   useMockData: boolean
+  /** Whether CLAUDE_CODE_DISABLE_1M_CONTEXT=1 is set — caps context window to 200k */
+  disable1MContext: boolean
   /** Open a file in the VS Code editor */
   bridgeOpenFile: (filePath: string, line?: number) => void
   /** Known sessions from the extension */
@@ -47,6 +49,7 @@ export function useVSCodeBridge(): BridgeHookResult {
   const [useMockData, setUseMockData] = useState(
     process.env.NEXT_PUBLIC_DEMO !== '0'
   )
+  const [disable1MContext, setDisable1MContext] = useState(false)
   const pendingEventsRef = useRef<SimulationEvent[]>([])
   const [, setEventVersion] = useState(0) // trigger re-render on new events
 
@@ -158,7 +161,8 @@ export function useVSCodeBridge(): BridgeHookResult {
     })
 
     const unsubConfig = bridge.onConfig((config) => {
-      setUseMockData(config.showMockData)
+      if (config.showMockData !== undefined) { setUseMockData(config.showMockData) }
+      if (config.disable1MContext !== undefined) { setDisable1MContext(config.disable1MContext) }
     })
 
     // Session lifecycle tracking
@@ -301,6 +305,7 @@ export function useVSCodeBridge(): BridgeHookResult {
     pendingEvents: pendingEventsRef.current,
     consumeEvents,
     useMockData,
+    disable1MContext,
     bridgeOpenFile,
     sessions,
     selectedSessionId,

--- a/web/lib/vscode-bridge.ts
+++ b/web/lib/vscode-bridge.ts
@@ -12,7 +12,7 @@ import type { AgentEvent, SessionInfo, ConnectionStatus } from './bridge-types'
 type InitCallback = () => void
 type EventCallback = (event: AgentEvent) => void
 type StatusCallback = (status: ConnectionStatus, source: string) => void
-type ConfigCallback = (config: { mode: string; autoPlay: boolean; showMockData: boolean }) => void
+type ConfigCallback = (config: Partial<{ mode: string; autoPlay: boolean; showMockData: boolean; disable1MContext: boolean }>) => void
 type SessionCallback = (type: 'list' | 'started' | 'ended' | 'updated' | 'reset', data: SessionInfo[] | SessionInfo | string | { sessionId: string; label: string }) => void
 
 class VSCodeBridge {


### PR DESCRIPTION
Reads the flag from process.env and ~/.claude/settings.json → env, sends it to the webview via partial config message, and caps the context window to 200k for all models when set.

Fixes patoles/agent-flow#28

## What does this PR do?

The context gauge always showed 1000k for Opus/Sonnet 4.6 models, even when `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` was set. This PR:

- Adds `isDisable1MContext()` in the extension host that checks both `process.env` and `~/.claude/settings.json` → `env`
- Sends a partial config message to the webview on ready when the flag is detected
- Caps `getContextWindowSize()` to 200k for all models when the flag is active
- Refactors `hooks-config.ts` to extract a shared `GLOBAL_SETTINGS_PATH` constant and `readGlobalSettings()` helper, removing 4 duplicate path constructions
- Makes `VisualizerConfig` messages partial so config updates don't override unrelated fields

## How to test

1. Add `"env": { "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1" }` to `~/.claude/settings.json`
2. Open the extension (F5 or `npm run dev:extension`)
3. Start a Claude Code session using Opus or Sonnet 4.6
4. Verify the context gauge shows **200k** max instead of **1000k**
5. Remove the env setting and restart — gauge should show **1000k** again

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)