### PR TITLE
Remove dead resetMsgIdCounter function

### DIFF
--- a/web/hooks/simulation/types.ts
+++ b/web/hooks/simulation/types.ts
@@ -51,7 +51,6 @@ export function createEmptyState(overrides?: Partial<SimulationState>): Simulati
 
 let _msgIdCounter = 0
 export function nextMsgId(): string { return `msg-${_msgIdCounter++}` }
-export function resetMsgIdCounter(): void { /* noop — keep counter monotonic to avoid duplicate React keys */ }
 
 export interface ConversationMessage {
   id: string

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -13,7 +13,7 @@ import { TOOL_CARD_W, TOOL_CARD_H, FORCE, TOOL_SLOT, BUBBLE_VISIBLE_S, MODEL_CON
 import { forceSimulation, forceLink, forceManyBody, forceCenter, forceCollide, type Simulation } from 'd3-force'
 
 import type { SimulationState, ForceNode, ForceLink, UseAgentSimulationOptions } from './simulation/types'
-import { createEmptyState, resetMsgIdCounter, MAX_EVENT_LOG } from './simulation/types'
+import { createEmptyState, MAX_EVENT_LOG } from './simulation/types'
 import { processEvent, type ProcessEventContext } from './simulation/process-event'
 import { computeNextFrame } from './simulation/animate'
 import { snapVisualState } from './simulation/snap-visual-state'
@@ -312,7 +312,6 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
 
   const restart = useCallback((keepActive = false) => {
     blockIdCounter.current = 0
-    resetMsgIdCounter()
     if (!keepActive) {
       commitState(createEmptyState({ isPlaying: true, speed: frameRef.current.speed }))
       return


### PR DESCRIPTION
Follow-up to #33 which made it a noop. Removes the function, its import, and its call site — the counter is now always monotonically increasing by design.

## What does this PR do?

Cleans up the `resetMsgIdCounter()` function that #33 turned into a noop. Removes:
- The function definition in `web/hooks/simulation/types.ts`
- The import in `web/hooks/use-agent-simulation.ts`
- The call site in `restart()`

No behavior change — the function was already a noop.

## How to test

1. Run `npm run build:all` — no errors
2. Switch between sessions repeatedly — no duplicate key warnings in console
3. Restart a session — still works correctly

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)