### PR TITLE
Fix Windows hook deduplication by normalizing path separators

### DIFF
--- a/extension/src/hooks-config.ts
+++ b/extension/src/hooks-config.ts
@@ -29,7 +29,9 @@ function readGlobalSettings(): Record<string, unknown> | null {
 /** Check whether a single hook entry belongs to Agent Flow */
 function isAgentFlowHook(entry: ClaudeHookEntry): boolean {
   return !!entry.hooks?.some(h =>
-    h.command?.includes(HOOK_COMMAND_MARKER) ||
+    // Normalize backslashes to forward slashes so Windows paths
+    // (e.g. "C:\\Users\\...\\agent-flow\\hook.js") match HOOK_COMMAND_MARKER.
+    h.command?.replace(/\\/g, '/').includes(HOOK_COMMAND_MARKER) ||
     h.url?.startsWith(HOOK_URL_PREFIX),
   )
 }


### PR DESCRIPTION
`isAgentFlowHook` checked `h.command.includes('agent-flow/hook.js')`, but on Windows the command string contains backslashes so the marker never matched. Old hook entries were never removed, causing settings.json to accumulate duplicate entries on every registration.

Fixes patoles/agent-flow#41

## What does this PR do?

`isAgentFlowHook` in `extension/src/hooks-config.ts` now normalizes backslashes to forward slashes before the `includes(HOOK_COMMAND_MARKER)` check. On Windows, `HOOK_SCRIPT_PATH` is built with `path.join` which uses backslashes, so the stored command (e.g. `"C:\Users\...\agent-flow\hook.js"`) never matched the forward-slash marker. As a result, every hook re-registration appended a new entry without deduping, and one user reported 126 duplicate entries in their `settings.json`.

The fix is a single-line change — existing POSIX platforms are unaffected (strings without backslashes pass through `.replace` unchanged).

Note: existing Windows users with bloated `settings.json` will have their old duplicates deduplicated automatically on the next hook registration once they install the fixed version.

## How to test

1. On Windows, register Agent Flow hooks
2. Re-run `agentVisualizer.configureHooks` several times
3. Inspect `~/.claude/settings.json` — each hook event (`SessionStart`, `PreToolUse`, etc.) should contain exactly **one** agent-flow entry, not one per registration

On macOS/Linux, verify existing behavior is unchanged (single entry per event, no regression).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)