### PR TITLE
Feat/opus 4 7 support

### DIFF
--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -53,6 +53,26 @@ function safeThinking(block: unknown): string {
   return String(block.thinking || '').trim()
 }
 
+/** Returns the signature string if a thinking block is redacted
+ *  (plaintext stripped but signature present, as Opus 4.7+ does), else null. */
+function redactedThinkingSignature(block: unknown): string | null {
+  if (!isRecord(block)) return null
+  if (String(block.thinking || '').trim()) return null
+  const sig = block.signature
+  return typeof sig === 'string' && sig.length > 0 ? sig : null
+}
+
+/** Build the dedup hash key for a thinking block. Prefers the transcript entry
+ *  UUID; falls back to a prefix of the content (or signature, for redacted blocks). */
+function thinkingHashKey(entryUuid: string | undefined, fallbackSource: string): string {
+  return entryUuid
+    ? `thinking:${entryUuid}`
+    : `thinking:${fallbackSource.slice(0, HASH_PREFIX_MAX)}`
+}
+
+/** Placeholder shown for redacted thinking blocks (matches Claude Code's UI label). */
+const REDACTED_THINKING_LABEL = 'Thinking...'
+
 export class TranscriptParser {
   /** Per-subagent dedup state for inline progress events, keyed by parentToolUseID */
   private inlineSubagentState = new Map<string, {
@@ -211,7 +231,8 @@ export class TranscriptParser {
     }, sessionId)
   }
 
-  /** Process a thinking block — dedup, track tokens, emit message event */
+  /** Process a thinking block — dedup, track tokens, emit message event.
+   *  Redacted thinking (Opus 4.7+) is shown as a "Thinking..." placeholder. */
   private handleThinkingBlock(
     block: unknown,
     entryUuid: string | undefined,
@@ -221,17 +242,23 @@ export class TranscriptParser {
     sessionId?: string,
   ): void {
     const thinking = safeThinking(block)
-    if (!thinking) return
+    const redactedSig = thinking ? null : redactedThinkingSignature(block)
+    if (!thinking && !redactedSig) return
 
-    const hash = entryUuid ? `thinking:${entryUuid}` : `thinking:${thinking.slice(0, HASH_PREFIX_MAX)}`
+    const hash = thinkingHashKey(entryUuid, thinking || redactedSig || '')
     if (seenMsgs?.has(hash)) return
     seenMsgs?.add(hash)
 
-    if (session) { session.contextBreakdown.reasoning += estimateTokensFromText(thinking) }
+    // Reasoning tokens are unknown for redacted blocks — skip breakdown update
+    if (session && thinking) { session.contextBreakdown.reasoning += estimateTokensFromText(thinking) }
     this.delegate.emit({
       time: this.delegate.elapsed(sessionId),
       type: 'message',
-      payload: { agent: agentName, role: 'thinking', content: thinking.slice(0, MESSAGE_MAX) },
+      payload: {
+        agent: agentName,
+        role: 'thinking',
+        content: thinking ? thinking.slice(0, MESSAGE_MAX) : REDACTED_THINKING_LABEL,
+      },
     }, sessionId)
   }
 
@@ -449,10 +476,10 @@ export class TranscriptParser {
                 }
               } else if (block.type === 'thinking' && 'thinking' in block) {
                 const thinking = safeThinking(block)
-                if (thinking) {
-                  const hashKey = entry.uuid ? `thinking:${entry.uuid}` : `thinking:${thinking.slice(0, HASH_PREFIX_MAX)}`
-                  session.seenMessageHashes.add(hashKey)
-                  session.contextBreakdown.reasoning += estimateTokensFromText(thinking)
+                const redactedSig = thinking ? null : redactedThinkingSignature(block)
+                if (thinking || redactedSig) {
+                  session.seenMessageHashes.add(thinkingHashKey(entry.uuid, thinking || redactedSig || ''))
+                  if (thinking) { session.contextBreakdown.reasoning += estimateTokensFromText(thinking) }
                 }
               }
             }

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -9,7 +9,7 @@ import {
   type TimelineEntry,
 } from '@/lib/agent-types'
 import { MOCK_SCENARIO } from '@/lib/mock-scenario'
-import { TOOL_CARD_W, TOOL_CARD_H, FORCE, TOOL_SLOT, BUBBLE_VISIBLE_S, MODEL_CONTEXT_SIZES, DEFAULT_CONTEXT_SIZE, FALLBACK_CONTEXT_SIZE, ANIM_SPEED } from '@/lib/canvas-constants'
+import { TOOL_CARD_W, TOOL_CARD_H, FORCE, TOOL_SLOT, BUBBLE_VISIBLE_S, MODEL_FAMILY_CONTEXT, DEFAULT_CONTEXT_SIZE, FALLBACK_CONTEXT_SIZE, ANIM_SPEED } from '@/lib/canvas-constants'
 import { forceSimulation, forceLink, forceManyBody, forceCenter, forceCollide, type Simulation } from 'd3-force'
 
 import type { SimulationState, ForceNode, ForceLink, UseAgentSimulationOptions } from './simulation/types'
@@ -153,8 +153,8 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
   const getContextWindowSize = useCallback((modelId?: string): number => {
     if (!modelId) return disable1MContext ? DEFAULT_CONTEXT_SIZE : FALLBACK_CONTEXT_SIZE
     const id = modelId.toLowerCase()
-    for (const [key, size] of Object.entries(MODEL_CONTEXT_SIZES)) {
-      if (id.includes(key)) return disable1MContext ? Math.min(size, DEFAULT_CONTEXT_SIZE) : size
+    for (const { pattern, size } of MODEL_FAMILY_CONTEXT) {
+      if (pattern.test(id)) return disable1MContext ? Math.min(size, DEFAULT_CONTEXT_SIZE) : size
     }
     return DEFAULT_CONTEXT_SIZE
   }, [disable1MContext])

--- a/web/lib/canvas-constants.ts
+++ b/web/lib/canvas-constants.ts
@@ -1,10 +1,14 @@
 // ─── Model context sizes ────────────────────────────────────────────────────
 
-export const MODEL_CONTEXT_SIZES: Record<string, number> = {
-  'opus-4-6': 1_000_000,
-  'sonnet-4-6': 1_000_000,
-}
+/** Context window size by model family. Patterns are checked in order;
+ *  first match wins. Matched against lower-cased model IDs. */
+export const MODEL_FAMILY_CONTEXT: ReadonlyArray<{ pattern: RegExp; size: number }> = [
+  { pattern: /(opus|sonnet)-\d/, size: 1_000_000 },
+  { pattern: /haiku-\d/, size: 200_000 },
+]
+/** Used when no family pattern matches (unknown model). */
 export const DEFAULT_CONTEXT_SIZE = 200_000
+/** Used when no model ID is available at all. */
 export const FALLBACK_CONTEXT_SIZE = 1_000_000
 
 // ─── Visibility threshold ───────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Adds support for Claude Opus 4.7, addressing two regressions that surfaced when it shipped:

**1. Context window family matching** (`web/lib/canvas-constants.ts`, `web/hooks/use-agent-simulation.ts`)

Replaces the hardcoded `MODEL_CONTEXT_SIZES` map (which only knew about `opus-4-6` / `sonnet-4-6`) with `MODEL_FAMILY_CONTEXT`, a pattern-based table. Opus/Sonnet families match `/(opus|sonnet)-\d/` → 1M, Haiku matches `/haiku-\d/` → 200k, anything else falls to `DEFAULT_CONTEXT_SIZE`. Without this, `claude-opus-4-7` was falling through to the 200k default, so the context gauge under-reported capacity by 5×.

Bonus: future Opus/Sonnet releases will match automatically without another release.

**2. Redacted thinking placeholder** (`extension/src/transcript-parser.ts`)

Opus 4.7 returns thinking as an empty `thinking` field + opaque `signature` (encrypted server-side for replay, not decodable client-side). The parser previously dropped these silently, hiding that the model reasoned at all.

The parser now detects redacted thinking (via a new `redactedThinkingSignature` helper) and emits a `"Thinking..."` placeholder bubble — matching Claude Code's own UI label. Plaintext thinking from Opus 4.6 and earlier is unaffected. Reasoning tokens only accumulate when plaintext is available, since content length is unknown for redacted blocks.

Also extracts a small `thinkingHashKey` helper so the live handler and catch-up pre-scan share the same dedup key logic.

## How to test

**Context window:**
1. Start a Claude Code session using Opus 4.7 (or Sonnet 4.6)
2. Verify the context gauge shows **1M** max (not 200k)
3. Start a session using a Haiku model → gauge shows **200k**
4. Verify Opus 4.6 sessions still show **1M** (regression check)

**Redacted thinking:**
1. Start an Opus 4.7 session that does extended thinking
2. Verify a `"Thinking..."` bubble appears when the model reasons
3. Start an Opus 4.6 session → plaintext thinking renders as before

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)