### PR TITLE
Document AGENT_FLOW_RUNTIME in 0.8.0 changelog

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Codex runtime support** — available in all three entry points: VS Code extension, `pnpm run dev`, and `npx agent-flow-app`. Agent Flow now watches Codex rollouts at `~/.codex/sessions/**/rollout-*.jsonl` alongside Claude Code sessions
   - New `agentVisualizer.runtime` setting (VS Code only): `"auto"` (default, watches both), `"claude"`, or `"codex"`
+  - `AGENT_FLOW_RUNTIME` environment variable (`claude` / `codex` / `auto`) gives the same opt-out in `pnpm run dev` and `npx agent-flow-app`
   - Respects `CODEX_HOME` for non-default installs
   - Parses all five Codex rollout record types (`session_meta`, `turn_context`, `response_item`, `event_msg`, `compacted`) — surfaces tool calls (`exec_command`, `apply_patch`, `write_stdin`, `update_plan`), reasoning, web searches
   - Uses Codex's own authoritative token counts (`event_msg.token_count.info.last_token_usage.input_tokens` and `model_context_window`) instead of estimating


### PR DESCRIPTION
## Summary

One-line addition to the 0.8.0 changelog entry: the `AGENT_FLOW_RUNTIME` env var for `pnpm run dev` / `npx agent-flow-app` landed in the #44 review follow-ups, after the original changelog was written. Adds it before we cut the 0.8.0 release on the marketplace and npm.

## Test plan

- [ ] Verify the changelog entry reads correctly in GitHub's markdown preview