### PR TITLE
feat: anonymous usage telemetry (v0.8.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ Other scripts:
 
 Created by [Simon Patole](https://github.com/patoles), for [CraftMyGame](https://craftmygame.com).
 
+## Privacy & Telemetry
+
+Agent Flow ships **opt-out** anonymous usage telemetry. On by default. Only
+aggregate events (session count, duration, OS, version, models observed,
+runtimes watched, error class) — never prompts, file paths, or code.
+
+- Turn off: `export AGENT_FLOW_TELEMETRY=false` or `export DO_NOT_TRACK=1`
+- Inspect the payload: `cat ~/.agent-flow/telemetry/events.jsonl`
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -138,12 +138,21 @@ Created by [Simon Patole](https://github.com/patoles), for [CraftMyGame](https:/
 
 ## Privacy & Telemetry
 
-Agent Flow ships **opt-out** anonymous usage telemetry. On by default. Only
-aggregate events (session count, duration, OS, version, models observed,
-runtimes watched, error class) — never prompts, file paths, or code.
+Agent Flow ships **opt-out** anonymous usage telemetry, enabled by default only
+in the published `npx agent-flow-app` binary. `pnpm run dev` and the VS Code
+extension emit nothing. Only aggregate events are sent — session count,
+duration, event count, OS/arch, Agent Flow version, distinct model IDs
+observed, which runtimes were watched, and error class names. Prompts, file
+paths, tool calls, user info, and environment variables are never sent.
 
-- Turn off: `export AGENT_FLOW_TELEMETRY=false` or `export DO_NOT_TRACK=1`
-- Inspect the payload: `cat ~/.agent-flow/telemetry/events.jsonl`
+- **Turn off:** `export AGENT_FLOW_TELEMETRY=false` or `export DO_NOT_TRACK=1`
+  (disabled installs write zero state to disk — no `~/.agent-flow/` directory)
+- **Inspect the payload:** `cat ~/.agent-flow/telemetry/events.jsonl`
+- **Full schema + exact fields:** see the v0.8.1 entry in
+  [extension/CHANGELOG.md](extension/CHANGELOG.md) or the `serialize()` function
+  in [scripts/telemetry.ts](scripts/telemetry.ts)
+- **Reset your anonymous identity:** delete `~/.agent-flow/installation-id` —
+  a fresh random UUIDv4 will be generated on next run
 
 ## License
 

--- a/app/build.js
+++ b/app/build.js
@@ -12,6 +12,7 @@ const path = require('path')
 
 const ROOT = path.join(__dirname, '..')
 const APP_DIR = __dirname
+const APP_PKG = require(path.join(APP_DIR, 'package.json'))
 
 console.log('Building Agent Flow app...\n')
 
@@ -32,6 +33,9 @@ esbuild.buildSync({
   outfile: path.join(APP_DIR, 'dist', 'app.js'),
   alias: {
     'vscode': path.join(ROOT, 'scripts', 'vscode-shim.js'),
+  },
+  define: {
+    AGENT_FLOW_APP_VERSION: JSON.stringify(APP_PKG.version),
   },
   banner: {
     js: '#!/usr/bin/env node',

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-flow-app",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Real-time visualization of AI agent orchestration — standalone web app",
   "bin": {
     "agent-flow": "dist/app.js"

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -3,9 +3,12 @@
  * Reuses the extension's hook server, transcript parser, and session watcher.
  */
 import * as http from 'http'
+import * as os from 'os'
+import * as path from 'path'
 import { exec, execFile } from 'child_process'
 
 import { createRelay } from '../../scripts/relay'
+import { createTelemetryClient } from '../../scripts/telemetry'
 import { serveStatic } from './static'
 
 interface ServerOptions {
@@ -18,7 +21,14 @@ interface ServerOptions {
 export async function startServer(options: ServerOptions) {
   const { port, openBrowser, workspace } = options
 
-  const relay = await createRelay({ workspace, verbose: options.verbose })
+  const configDir = path.join(os.homedir(), '.agent-flow')
+  const telemetry = createTelemetryClient({
+    logDir: path.join(configDir, 'telemetry'),
+    installIdPath: path.join(configDir, 'installation-id'),
+  })
+  await telemetry.init()
+
+  const relay = await createRelay({ workspace, verbose: options.verbose, telemetry })
 
   const server = http.createServer((req, res) => {
     // SSE endpoint
@@ -45,11 +55,16 @@ export async function startServer(options: ServerOptions) {
     }
   })
 
-  // Cleanup on exit
+  // Cleanup on exit. Idempotent — repeat signals (Ctrl+C spam, SIGTERM+SIGHUP,
+  // etc.) would otherwise emit duplicate session_end events and race the
+  // telemetry sync loop against itself.
+  let shuttingDown = false
   function cleanup() {
+    if (shuttingDown) return
+    shuttingDown = true
     server.close()
     relay.dispose()
-    process.exit(0)
+    void telemetry.dispose().finally(() => process.exit(0))
   }
   process.on('SIGINT', cleanup)
   process.on('SIGTERM', cleanup)

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -68,6 +68,10 @@ export async function startServer(options: ServerOptions) {
   }
   process.on('SIGINT', cleanup)
   process.on('SIGTERM', cleanup)
+  // SIGHUP fires when the controlling terminal closes (SSH session drops, tmux
+  // pane killed). Without a handler, Node's default behavior is to terminate
+  // without running cleanup — so session_end never flushes.
+  process.on('SIGHUP', cleanup)
 }
 
 function openURL(url: string) {

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.8.1
+
+- **Opt-out anonymous usage telemetry** — Agent Flow now tracks whether people come back after day 1 so we can tell whether it's actually useful. Only aggregate session metadata is sent, never prompts, file paths, or code
+  - What's sent: session count, duration, event count, OS/arch, Agent Flow version, distinct Claude/Codex model IDs observed during each session, which runtimes were watched (`claude`, `codex`, or `claude,codex`), and error class names on crashes
+  - What's NEVER sent: prompts, tool calls, tool responses, file paths, repo names, user name/email/hostname, environment variables, error messages or stack traces
+  - Turn off: `export AGENT_FLOW_TELEMETRY=false` or `export DO_NOT_TRACK=1`. Disabled installs write nothing to disk — no `~/.agent-flow/` state file, no telemetry dir
+  - Only the published `npx agent-flow-app` binary emits. `pnpm run dev` stays silent so contributor iterations don't land in the data
+  - Inspect the exact payload locally: `cat ~/.agent-flow/telemetry/events.jsonl`
+- Remove `@vercel/analytics` — conflicts with the first-party-only commitment in the privacy doc
+
 ## 0.8.0
 
 - **Codex runtime support** — available in all three entry points: VS Code extension, `pnpm run dev`, and `npx agent-flow-app`. Agent Flow now watches Codex rollouts at `~/.codex/sessions/**/rollout-*.jsonl` alongside Claude Code sessions

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-flow",
   "displayName": "Agent Flow",
   "description": "Real-time visualization of Claude Code and Codex agent orchestration",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "publisher": "simon-p",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "build:web": "pnpm --filter agent-flow-web run build",
     "build:webview": "pnpm --filter agent-flow-web run build:webview",
     "build:all": "pnpm run build:webview && pnpm run build:extension",
-    "build:app": "node app/build.js"
+    "build:app": "node app/build.js",
+    "test": "node --import tsx --test \"scripts/**/*.test.ts\" \"app/src/**/*.test.ts\""
   },
   "devDependencies": {
     "concurrently": "^9.2.1",
-    "esbuild": "^0.20.2"
+    "esbuild": "^0.20.2",
+    "tsx": "^4.21.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       esbuild:
         specifier: ^0.20.2
         version: 0.20.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
   extension:
     devDependencies:
@@ -35,9 +38,6 @@ importers:
 
   web:
     dependencies:
-      '@vercel/analytics':
-        specifier: 1.6.1
-        version: 1.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       d3-force:
         specifier: ^3.0.0
         version: 3.0.0
@@ -427,105 +427,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -589,28 +573,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -662,42 +642,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
     resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
@@ -769,28 +743,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -850,32 +820,6 @@ packages:
 
   '@types/vscode@1.110.0':
     resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
-
-  '@vercel/analytics@1.6.1':
-    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -1044,28 +988,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1766,11 +1706,6 @@ snapshots:
       csstype: 3.2.3
 
   '@types/vscode@1.110.0': {}
-
-  '@vercel/analytics@1.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
-    optionalDependencies:
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.2(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -21,6 +21,7 @@ import {
   HOOK_SERVER_NOT_STARTED, WORKSPACE_HASH_LENGTH,
 } from '../extension/src/constants'
 import { setLogLevel } from '../extension/src/logger'
+import type { TelemetryClient } from './telemetry'
 
 const MAX_EVENT_BUFFER = 5000
 const DISCOVERY_DIR = path.join(os.homedir(), '.claude', 'agent-flow')
@@ -28,6 +29,29 @@ const CLAUDE_DIR = path.join(os.homedir(), '.claude', 'projects')
 
 let relayCreated = false
 let verbose = false
+let sessionEventCount = 0
+/** Distinct model IDs seen across all watched sessions during this relay session.
+ *  Populated from `model_detected` events (emitted by both the Claude transcript
+ *  parser and the Codex rollout parser). Read at session_end for telemetry. */
+const observedModels = new Set<string>()
+
+// agent-flow-app version. Inlined by esbuild at bundle time via `define`.
+// In dev (running from source via tsx), falls back to reading app/package.json.
+declare const AGENT_FLOW_APP_VERSION: string | undefined
+function resolveAgentFlowVersion(): string {
+  try {
+    if (typeof AGENT_FLOW_APP_VERSION === 'string' && AGENT_FLOW_APP_VERSION) {
+      return AGENT_FLOW_APP_VERSION
+    }
+  } catch { /* ReferenceError in unbundled dev — fall through */ }
+  try {
+    const pkgPath = path.join(__dirname, '..', 'app', 'package.json')
+    if (fs.existsSync(pkgPath)) {
+      return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version ?? '0.0.0'
+    }
+  } catch { /* ignore */ }
+  return '0.0.0'
+}
 
 function log(...args: unknown[]) {
   if (verbose) console.log(...args)
@@ -56,6 +80,11 @@ function broadcast(data: string) {
 const eventBuffer = new Map<string, AgentEvent[]>()
 
 function broadcastEvent(event: AgentEvent) {
+  sessionEventCount++
+  if (event.type === 'model_detected') {
+    const m = (event.payload as { model?: unknown } | undefined)?.model
+    if (typeof m === 'string' && m.length > 0) observedModels.add(m)
+  }
   const sid = event.sessionId?.slice(0, SESSION_ID_DISPLAY) || '?'
   log(`[event] ${event.type} (session ${sid})`)
 
@@ -329,6 +358,7 @@ export type RelayRuntimeMode = 'claude' | 'codex' | 'auto'
 export interface RelayOptions {
   workspace: string
   verbose?: boolean
+  telemetry?: TelemetryClient
   /** Which runtimes to watch. Defaults to AGENT_FLOW_RUNTIME env var, or 'auto'.
    *  Mirrors the extension's `agentVisualizer.runtime` setting so users of the
    *  dev relay and `npx agent-flow-app` have a way to opt out of one runtime. */
@@ -403,6 +433,36 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
     codexWatcher.start()
   }
 
+  const telemetry = options.telemetry
+  const sessionStart = Date.now()
+  let relayDisposed = false
+  const relaySessionId = `relay-${process.pid}-${Math.floor(sessionStart / 1000)}`
+  sessionEventCount = 0
+
+  const agentFlowVersion = resolveAgentFlowVersion()
+
+  const baseEvent = () => ({
+    session_id: relaySessionId,
+    agent_flow_version: agentFlowVersion,
+    os: os.platform(),
+    arch: os.arch(),
+  })
+
+  telemetry?.emit({ ...baseEvent(), event_type: 'session_start' })
+
+  process.on('uncaughtException', (err) => {
+    try {
+      telemetry?.emit({
+        ...baseEvent(),
+        event_type: 'error',
+        error_class: err?.constructor?.name ?? 'Error',
+      })
+    } catch { /* don't let the handler itself crash */ }
+    // Preserve default crash-on-uncaught behavior: log, then exit.
+    console.error(err)
+    process.exit(1)
+  })
+
   return {
     handleSSE(req: http.IncomingMessage, res: http.ServerResponse) {
       res.writeHead(200, {
@@ -450,6 +510,20 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
     },
 
     dispose() {
+      // Defense in depth — server.ts already guards cleanup(), but direct
+      // callers or hot-reload could call this twice.
+      if (relayDisposed) return
+      relayDisposed = true
+      const models = [...observedModels].sort().join(',').slice(0, 128)
+      const runtimes = [wantClaude && 'claude', wantCodex && 'codex'].filter(Boolean).join(',')
+      telemetry?.emit({
+        ...baseEvent(),
+        event_type: 'session_end',
+        duration_s: Math.round((Date.now() - sessionStart) / 1000),
+        event_count: sessionEventCount,
+        models: models || undefined,
+        runtimes: runtimes || undefined,
+      })
       if (wantClaude) {
         removeDiscoveryFile()
         hookServer?.dispose()

--- a/scripts/telemetry.test.ts
+++ b/scripts/telemetry.test.ts
@@ -1,0 +1,143 @@
+import { test } from 'node:test'
+import { strict as assert } from 'node:assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { createTelemetryClient, isTelemetryEnabled, TELEMETRY_ENDPOINT, TELEMETRY_PUBLISHABLE_KEY } from './telemetry'
+
+function setup() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-tel-'))
+}
+
+function makeClient(dir: string) {
+  return createTelemetryClient({
+    logDir: path.join(dir, 'telemetry'),
+    installIdPath: path.join(dir, 'installation-id'),
+    // Unroutable so tests never hit the real endpoint.
+    endpoint: 'http://127.0.0.1:1',
+    apiKey: 'test',
+  })
+}
+
+function baseEvent() {
+  return {
+    event_type: 'session_start' as const,
+    session_id: 's-1',
+    agent_flow_version: '0.0.1',
+    os: 'darwin',
+    arch: 'arm64',
+  }
+}
+
+test('hardcoded constants are present', () => {
+  assert.match(TELEMETRY_ENDPOINT, /^https:\/\/.+\.supabase\.co$/)
+  assert.match(TELEMETRY_PUBLISHABLE_KEY, /^sb_publishable_/)
+})
+
+test('isTelemetryEnabled: default (no env) is true', () => {
+  assert.equal(isTelemetryEnabled({}), true)
+})
+
+test('isTelemetryEnabled: AGENT_FLOW_TELEMETRY=false disables', () => {
+  assert.equal(isTelemetryEnabled({ AGENT_FLOW_TELEMETRY: 'false' }), false)
+  assert.equal(isTelemetryEnabled({ AGENT_FLOW_TELEMETRY: '0' }), false)
+  assert.equal(isTelemetryEnabled({ AGENT_FLOW_TELEMETRY: 'disabled' }), false)
+  assert.equal(isTelemetryEnabled({ AGENT_FLOW_TELEMETRY: '' }), false)
+})
+
+test('isTelemetryEnabled: AGENT_FLOW_TELEMETRY=true stays enabled', () => {
+  assert.equal(isTelemetryEnabled({ AGENT_FLOW_TELEMETRY: 'true' }), true)
+  assert.equal(isTelemetryEnabled({ AGENT_FLOW_TELEMETRY: '1' }), true)
+})
+
+test('isTelemetryEnabled: DO_NOT_TRACK=1 disables', () => {
+  assert.equal(isTelemetryEnabled({ DO_NOT_TRACK: '1' }), false)
+  assert.equal(isTelemetryEnabled({ DO_NOT_TRACK: 'true' }), false)
+})
+
+test('isTelemetryEnabled: DO_NOT_TRACK wins even when AGENT_FLOW_TELEMETRY=true', () => {
+  assert.equal(isTelemetryEnabled({ AGENT_FLOW_TELEMETRY: 'true', DO_NOT_TRACK: '1' }), false)
+})
+
+test('emit appends to JSONL when enabled', async () => {
+  const dir = setup()
+  const client = makeClient(dir)
+  delete process.env.AGENT_FLOW_TELEMETRY
+  delete process.env.DO_NOT_TRACK
+  await client.init()
+  client.emit(baseEvent())
+  await client.dispose()
+  const jsonl = path.join(dir, 'telemetry', 'events.jsonl')
+  const lines = fs.readFileSync(jsonl, 'utf-8').trim().split('\n')
+  assert.equal(lines.length, 1)
+  const e = JSON.parse(lines[0])
+  assert.equal(e.v, 1)
+  assert.equal(e.event_type, 'session_start')
+  assert.match(e.installation_id, /^[0-9a-f-]{36}$/)
+  assert.match(e.ts, /^\d{4}-\d{2}-\d{2}T/)
+})
+
+test('disabled via AGENT_FLOW_TELEMETRY=false writes nothing to disk', async () => {
+  const dir = setup()
+  process.env.AGENT_FLOW_TELEMETRY = 'false'
+  try {
+    const client = makeClient(dir)
+    await client.init()
+    client.emit(baseEvent())
+    await client.dispose()
+    // No events log AND no install-id file — disabled means zero disk footprint.
+    assert.equal(fs.existsSync(path.join(dir, 'telemetry', 'events.jsonl')), false)
+    assert.equal(fs.existsSync(path.join(dir, 'installation-id')), false)
+  } finally {
+    delete process.env.AGENT_FLOW_TELEMETRY
+  }
+})
+
+test('disabled via DO_NOT_TRACK=1 writes nothing to disk', async () => {
+  const dir = setup()
+  process.env.DO_NOT_TRACK = '1'
+  try {
+    const client = makeClient(dir)
+    await client.init()
+    client.emit(baseEvent())
+    await client.dispose()
+    assert.equal(fs.existsSync(path.join(dir, 'telemetry', 'events.jsonl')), false)
+    assert.equal(fs.existsSync(path.join(dir, 'installation-id')), false)
+  } finally {
+    delete process.env.DO_NOT_TRACK
+  }
+})
+
+test('install-id persists across init calls', async () => {
+  const dir = setup()
+  delete process.env.AGENT_FLOW_TELEMETRY
+  delete process.env.DO_NOT_TRACK
+  const client1 = makeClient(dir)
+  await client1.init()
+  client1.emit(baseEvent())
+  await client1.dispose()
+  const idPath = path.join(dir, 'installation-id')
+  const id1 = fs.readFileSync(idPath, 'utf-8').trim()
+
+  const client2 = makeClient(dir)
+  await client2.init()
+  client2.emit(baseEvent())
+  await client2.dispose()
+  const lines = fs.readFileSync(path.join(dir, 'telemetry', 'events.jsonl'), 'utf-8').trim().split('\n')
+  for (const line of lines) {
+    assert.equal(JSON.parse(line).installation_id, id1)
+  }
+})
+
+test('emit sanitizes session_id', async () => {
+  const dir = setup()
+  delete process.env.AGENT_FLOW_TELEMETRY
+  delete process.env.DO_NOT_TRACK
+  const client = makeClient(dir)
+  await client.init()
+  client.emit({ ...baseEvent(), session_id: 'quote"backslash\\newline\n' })
+  await client.dispose()
+  const jsonl = path.join(dir, 'telemetry', 'events.jsonl')
+  const e = JSON.parse(fs.readFileSync(jsonl, 'utf-8').trim())
+  assert.equal(e.session_id, 'quotebackslashnewline')
+})

--- a/scripts/telemetry.ts
+++ b/scripts/telemetry.ts
@@ -1,0 +1,207 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { getOrCreateInstallId } from './telemetry/install-id'
+import { sanitizeString } from './telemetry/sanitize'
+import { syncOnce } from './telemetry/sync'
+
+/**
+ * Hardcoded telemetry endpoint + publishable key.
+ *
+ * These ship inside every published binary. No env var override, no runtime
+ * fallback. All enabled installs send events to Agent Flow's Supabase project.
+ * Forks that republish under a different name must edit these constants and
+ * rebuild.
+ *
+ * Safe to commit: publishable keys are designed to be public. Postgres RLS
+ * denies the anon role everything; the only write path is the telemetry-ingest
+ * edge function, which runs under the secret key and validates every event.
+ */
+export const TELEMETRY_ENDPOINT = 'https://dxwtgqdkyunfhbywqmrz.supabase.co'
+export const TELEMETRY_PUBLISHABLE_KEY = 'sb_publishable_AgJ_DIUH9zm8E0yHC9KsRw_WsIv4qc8'
+
+/**
+ * Progressive sync schedule. After init(), fire syncs at these offsets:
+ *   - 2s (captures session_start that the relay emits right after init)
+ *   - +2min
+ *   - +3min
+ *   - then every 5min
+ *
+ * Short sessions get flushed quickly; long sessions settle into steady cadence.
+ */
+const FIRST_SYNC_DELAY_MS = 2 * 1000
+const SYNC_SCHEDULE_MS = [2 * 60 * 1000, 3 * 60 * 1000]
+const SYNC_REPEAT_MS = 5 * 60 * 1000
+
+const FALSY_VALUES = new Set(['false', '0', 'disabled', ''])
+
+export interface TelemetryEvent {
+  event_type: 'session_start' | 'session_end' | 'error'
+  session_id: string
+  agent_flow_version: string
+  os: string
+  arch: string
+  source?: string
+  duration_s?: number
+  event_count?: number
+  error_class?: string
+  /** Comma-separated distinct model IDs observed during the session
+   *  (e.g., `"claude-opus-4-7,gpt-5"`). session_end only. */
+  models?: string
+  /** Which runtimes were being watched: `"claude"`, `"codex"`, or `"claude,codex"`.
+   *  session_end only. */
+  runtimes?: string
+}
+
+export interface TelemetryClientOptions {
+  /** Directory for events.jsonl and .cursor. Usually `~/.agent-flow/telemetry`. */
+  logDir: string
+  /** Path to the stable install UUID. Usually `~/.agent-flow/installation-id`. */
+  installIdPath: string
+  /** Override for tests. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv
+  /** Override the endpoint for tests. Defaults to the hardcoded constant. */
+  endpoint?: string
+  /** Override the key for tests. Defaults to the hardcoded constant. */
+  apiKey?: string
+}
+
+export interface TelemetryClient {
+  /** Resolve install ID and start the sync timer when telemetry is enabled. */
+  init(): Promise<void>
+  /** Append an event to the JSONL log. No-op when disabled. */
+  emit(event: TelemetryEvent): void
+  /** Current enabled state. Re-evaluated from env on every call. */
+  isEnabled(): boolean
+  /** Stop the sync timer and do a final flush. */
+  dispose(): Promise<void>
+}
+
+/**
+ * Pure function: given an env record, return true if telemetry should emit.
+ *
+ * Rules:
+ * - `DO_NOT_TRACK` truthy → disabled (wins over everything)
+ * - `AGENT_FLOW_TELEMETRY` falsy (`false`, `0`, `disabled`, ``) → disabled
+ * - Otherwise enabled (including when AGENT_FLOW_TELEMETRY is unset)
+ */
+export function isTelemetryEnabled(env: NodeJS.ProcessEnv): boolean {
+  const dnt = env.DO_NOT_TRACK
+  if (dnt !== undefined && dnt !== '' && dnt !== '0' && dnt.toLowerCase() !== 'false') {
+    return false
+  }
+  const flag = env.AGENT_FLOW_TELEMETRY
+  if (flag !== undefined && FALSY_VALUES.has(flag.toLowerCase())) {
+    return false
+  }
+  return true
+}
+
+export function createTelemetryClient(opts: TelemetryClientOptions): TelemetryClient {
+  const logDir = opts.logDir
+  const jsonlPath = path.join(logDir, 'events.jsonl')
+  const cursorPath = path.join(logDir, '.cursor')
+  const endpoint = opts.endpoint ?? TELEMETRY_ENDPOINT
+  const apiKey = opts.apiKey ?? TELEMETRY_PUBLISHABLE_KEY
+  const getEnv = () => opts.env ?? process.env
+
+  let installId = ''
+  let syncTimer: NodeJS.Timeout | null = null
+  let disposed = false
+  /** Promise for the currently-running sync, or null if idle. Prevents two
+   *  syncOnce calls from racing on the cursor file — the scheduled sync and
+   *  dispose's final sync used to both read cursor=N before either advanced
+   *  it, POSTing overlapping batches and double-inserting. */
+  let syncInFlight: Promise<unknown> | null = null
+
+  function enabled(): boolean {
+    return isTelemetryEnabled(getEnv())
+  }
+
+  function serialize(event: TelemetryEvent): string {
+    return JSON.stringify({
+      v: 1,
+      ts: new Date().toISOString(),
+      event_type: event.event_type,
+      installation_id: installId,
+      session_id: sanitizeString(event.session_id),
+      agent_flow_version: sanitizeString(event.agent_flow_version),
+      os: sanitizeString(event.os, 16),
+      arch: sanitizeString(event.arch, 16),
+      source: sanitizeString(event.source ?? 'npx', 32),
+      duration_s: event.duration_s ?? null,
+      event_count: event.event_count ?? null,
+      error_class: event.error_class ? sanitizeString(event.error_class, 64) : null,
+      models: event.models ? sanitizeString(event.models, 128) : null,
+      runtimes: event.runtimes ? sanitizeString(event.runtimes, 32) : null,
+    })
+  }
+
+  function append(event: TelemetryEvent) {
+    if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true })
+    fs.appendFileSync(jsonlPath, serialize(event) + '\n', { mode: 0o600 })
+  }
+
+  function fireSync() {
+    if (syncInFlight) return // another sync is already running — skip, not queue
+    syncInFlight = syncOnce({ jsonlPath, cursorPath, endpoint, apiKey })
+      .catch(() => {
+        // Swallow — next tick retries from the same cursor position.
+      })
+      .finally(() => { syncInFlight = null })
+  }
+
+  function scheduleNext(idx: number) {
+    const delay = idx < SYNC_SCHEDULE_MS.length ? SYNC_SCHEDULE_MS[idx] : SYNC_REPEAT_MS
+    syncTimer = setTimeout(() => {
+      fireSync()
+      scheduleNext(idx + 1)
+    }, delay)
+    syncTimer.unref?.()
+  }
+
+  function startSync() {
+    if (syncTimer) return
+    // First sync on a short delay so the relay can write session_start first.
+    syncTimer = setTimeout(() => {
+      fireSync()
+      scheduleNext(0)
+    }, FIRST_SYNC_DELAY_MS)
+    syncTimer.unref?.()
+  }
+
+  function stopSync() {
+    if (syncTimer) { clearTimeout(syncTimer); syncTimer = null }
+  }
+
+  return {
+    async init() {
+      // When disabled, write nothing to disk — no install-id, no telemetry/ dir.
+      if (!enabled()) return
+      installId = getOrCreateInstallId(opts.installIdPath)
+      startSync()
+    },
+
+    emit(event: TelemetryEvent) {
+      if (!enabled()) return
+      // Lazy install-id init in case env toggled between init() and emit().
+      if (!installId) installId = getOrCreateInstallId(opts.installIdPath)
+      append(event)
+    },
+
+    isEnabled() {
+      return enabled()
+    },
+
+    async dispose() {
+      if (disposed) return
+      disposed = true
+      stopSync()
+      // Wait for any in-flight scheduled sync to finish so our final flush
+      // starts from an up-to-date cursor.
+      if (syncInFlight) { try { await syncInFlight } catch { /* best effort */ } }
+      if (enabled()) {
+        try { await syncOnce({ jsonlPath, cursorPath, endpoint, apiKey }) } catch { /* best effort */ }
+      }
+    },
+  }
+}

--- a/scripts/telemetry/install-id.ts
+++ b/scripts/telemetry/install-id.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import * as crypto from 'crypto'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+/**
+ * Reads the installation ID from `filePath`, or generates a fresh UUID v4 and
+ * writes it if the file is missing or contains invalid data.
+ *
+ * The file is chmod 0600 (user read/write only) since it's a stable identifier.
+ */
+export function getOrCreateInstallId(filePath: string): string {
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, 'utf-8').trim()
+    if (UUID_REGEX.test(existing)) return existing
+  }
+  const dir = path.dirname(filePath)
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  const id = crypto.randomUUID()
+  fs.writeFileSync(filePath, id + '\n', { mode: 0o600 })
+  return id
+}

--- a/scripts/telemetry/sanitize.test.ts
+++ b/scripts/telemetry/sanitize.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test'
+import { strict as assert } from 'node:assert'
+import { sanitizeString } from './sanitize'
+
+test('strips double quotes', () => {
+  assert.equal(sanitizeString('he"llo'), 'hello')
+})
+
+test('strips backslashes', () => {
+  assert.equal(sanitizeString('he\\llo'), 'hello')
+})
+
+test('strips control characters', () => {
+  assert.equal(sanitizeString('he\x00\x01\x1fllo'), 'hello')
+})
+
+test('strips newlines and tabs', () => {
+  assert.equal(sanitizeString('he\n\tllo'), 'hello')
+})
+
+test('caps length at 200 by default', () => {
+  const input = 'x'.repeat(300)
+  assert.equal(sanitizeString(input).length, 200)
+})
+
+test('respects custom length cap', () => {
+  assert.equal(sanitizeString('x'.repeat(100), 50).length, 50)
+})
+
+test('returns empty string for non-string input', () => {
+  // @ts-expect-error intentional
+  assert.equal(sanitizeString(null), '')
+  // @ts-expect-error intentional
+  assert.equal(sanitizeString(undefined), '')
+  // @ts-expect-error intentional
+  assert.equal(sanitizeString(123), '')
+})

--- a/scripts/telemetry/sanitize.ts
+++ b/scripts/telemetry/sanitize.ts
@@ -1,0 +1,14 @@
+const DEFAULT_MAX = 200
+
+/**
+ * Strips characters that would break JSON serialization or exceed size caps.
+ *
+ * Removes: double quotes, backslashes, all control characters (0x00-0x1F + 0x7F).
+ * Returns empty string for non-string input.
+ * Truncates to `maxLen` (default 200) if longer.
+ */
+export function sanitizeString(input: unknown, maxLen: number = DEFAULT_MAX): string {
+  if (typeof input !== 'string') return ''
+  const cleaned = input.replace(/["\\\x00-\x1F\x7F]/g, '')
+  return cleaned.length > maxLen ? cleaned.slice(0, maxLen) : cleaned
+}

--- a/scripts/telemetry/sync.test.ts
+++ b/scripts/telemetry/sync.test.ts
@@ -1,0 +1,102 @@
+import { test } from 'node:test'
+import { strict as assert } from 'node:assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { syncOnce } from './sync'
+
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-flow-sync-'))
+  return {
+    jsonlPath: path.join(dir, 'events.jsonl'),
+    cursorPath: path.join(dir, '.cursor'),
+  }
+}
+
+function makeEvent(i: number) {
+  return JSON.stringify({
+    v: 1,
+    ts: new Date().toISOString(),
+    event_type: 'session_start',
+    installation_id: 'a1b2c3d4-5678-4abc-9def-000000000000',
+    session_id: `s-${i}`,
+    agent_flow_version: '0.0.1',
+    os: 'darwin',
+    arch: 'arm64',
+  })
+}
+
+test('noop when jsonl does not exist', async () => {
+  const { jsonlPath, cursorPath } = setup()
+  const result = await syncOnce({
+    jsonlPath,
+    cursorPath,
+    endpoint: 'http://unused',
+    apiKey: 'x',
+    fetch: (async () => { throw new Error('should not fetch') }) as unknown as typeof fetch,
+  })
+  assert.equal(result.sent, 0)
+  assert.equal(result.reason, 'no_events_file')
+})
+
+test('noop when cursor is caught up', async () => {
+  const { jsonlPath, cursorPath } = setup()
+  fs.writeFileSync(jsonlPath, makeEvent(1) + '\n')
+  fs.writeFileSync(cursorPath, '1')
+  const result = await syncOnce({
+    jsonlPath,
+    cursorPath,
+    endpoint: 'http://unused',
+    apiKey: 'x',
+    fetch: (async () => { throw new Error('should not fetch') }) as unknown as typeof fetch,
+  })
+  assert.equal(result.sent, 0)
+  assert.equal(result.reason, 'cursor_caught_up')
+})
+
+test('sends unsent events and advances cursor on 2xx + inserted>0', async () => {
+  const { jsonlPath, cursorPath } = setup()
+  fs.writeFileSync(jsonlPath, [makeEvent(1), makeEvent(2), makeEvent(3)].join('\n') + '\n')
+  let captured: string | undefined
+  const fakeFetch = (async (_url: string, init: { body: string }) => {
+    captured = init.body
+    return new Response(JSON.stringify({ inserted: 3, rejected: 0 }), { status: 200 })
+  }) as unknown as typeof fetch
+  const result = await syncOnce({ jsonlPath, cursorPath, endpoint: 'http://e', apiKey: 'k', fetch: fakeFetch })
+  assert.equal(result.sent, 3)
+  const parsed = JSON.parse(captured!)
+  assert.equal(parsed.length, 3)
+  assert.equal(fs.readFileSync(cursorPath, 'utf-8').trim(), '3')
+})
+
+test('does not advance cursor when inserted==0', async () => {
+  const { jsonlPath, cursorPath } = setup()
+  fs.writeFileSync(jsonlPath, makeEvent(1) + '\n')
+  const fakeFetch = (async () => new Response(JSON.stringify({ inserted: 0, rejected: 1 }), { status: 200 })) as unknown as typeof fetch
+  const result = await syncOnce({ jsonlPath, cursorPath, endpoint: 'http://e', apiKey: 'k', fetch: fakeFetch })
+  assert.equal(result.sent, 0)
+  assert.equal(fs.existsSync(cursorPath), false)
+})
+
+test('does not advance cursor on 5xx', async () => {
+  const { jsonlPath, cursorPath } = setup()
+  fs.writeFileSync(jsonlPath, makeEvent(1) + '\n')
+  const fakeFetch = (async () => new Response('boom', { status: 503 })) as unknown as typeof fetch
+  const result = await syncOnce({ jsonlPath, cursorPath, endpoint: 'http://e', apiKey: 'k', fetch: fakeFetch })
+  assert.equal(result.sent, 0)
+  assert.equal(result.reason, 'http_error')
+})
+
+test('caps batch at 100 events', async () => {
+  const { jsonlPath, cursorPath } = setup()
+  const lines = Array.from({ length: 150 }, (_, i) => makeEvent(i)).join('\n') + '\n'
+  fs.writeFileSync(jsonlPath, lines)
+  let batchSize = 0
+  const fakeFetch = (async (_url: string, init: { body: string }) => {
+    batchSize = JSON.parse(init.body).length
+    return new Response(JSON.stringify({ inserted: batchSize, rejected: 0 }), { status: 200 })
+  }) as unknown as typeof fetch
+  const result = await syncOnce({ jsonlPath, cursorPath, endpoint: 'http://e', apiKey: 'k', fetch: fakeFetch })
+  assert.equal(result.sent, 100)
+  assert.equal(batchSize, 100)
+})

--- a/scripts/telemetry/sync.ts
+++ b/scripts/telemetry/sync.ts
@@ -73,6 +73,13 @@ export async function syncOnce(opts: SyncOptions): Promise<SyncResult> {
 
   if (!body.inserted || body.inserted <= 0) return { sent: 0, reason: 'nothing_inserted' }
 
+  // Advance by the full batch length, not body.inserted. This assumes the
+  // ingest edge function is all-or-nothing (either accepts the whole batch or
+  // rejects individual events against its schema and silently drops them).
+  // If the server ever moves to partial-insertion-with-rejection-offsets, this
+  // needs to change to advance by body.inserted or a returned offset list —
+  // otherwise events rejected in the middle of a batch would be re-sent on the
+  // next run, since cursor doesn't know which ones were dropped.
   const newCursor = cursor + batch.length
   fs.writeFileSync(opts.cursorPath, String(newCursor))
   return { sent: batch.length }

--- a/scripts/telemetry/sync.ts
+++ b/scripts/telemetry/sync.ts
@@ -1,0 +1,79 @@
+import * as fs from 'fs'
+
+const MAX_BATCH = 100
+const MAX_BODY_BYTES = 50 * 1024
+
+export interface SyncOptions {
+  jsonlPath: string
+  cursorPath: string
+  endpoint: string
+  apiKey: string
+  /** Override for tests. Defaults to global fetch. */
+  fetch?: typeof fetch
+}
+
+export interface SyncResult {
+  sent: number
+  reason?: string
+}
+
+/**
+ * Reads unsent events from `jsonlPath` starting at the line offset in `cursorPath`,
+ * POSTs a batch to `${endpoint}/functions/v1/telemetry-ingest`, and advances the
+ * cursor only if the response is 2xx AND body contains `inserted > 0`.
+ *
+ * All errors return a SyncResult with a reason — no throws. The next call picks up
+ * where this one left off.
+ */
+export async function syncOnce(opts: SyncOptions): Promise<SyncResult> {
+  const f = opts.fetch ?? fetch
+  if (!fs.existsSync(opts.jsonlPath)) return { sent: 0, reason: 'no_events_file' }
+
+  const content = fs.readFileSync(opts.jsonlPath, 'utf-8')
+  const allLines = content.split('\n').filter((l) => l.length > 0)
+  const totalLines = allLines.length
+
+  let cursor = 0
+  if (fs.existsSync(opts.cursorPath)) {
+    const n = parseInt(fs.readFileSync(opts.cursorPath, 'utf-8').trim(), 10)
+    if (!Number.isNaN(n) && n >= 0 && n <= totalLines) cursor = n
+  }
+  if (cursor >= totalLines) return { sent: 0, reason: 'cursor_caught_up' }
+
+  // Build batch, respecting MAX_BATCH and MAX_BODY_BYTES
+  const batch: unknown[] = []
+  let bodyBytes = 2 // opening and closing brackets
+  for (let i = cursor; i < totalLines && batch.length < MAX_BATCH; i++) {
+    const line = allLines[i]
+    if (bodyBytes + line.length + 1 > MAX_BODY_BYTES) break
+    try {
+      batch.push(JSON.parse(line))
+      bodyBytes += line.length + 1
+    } catch {
+      // Skip malformed lines. They'll be passed over as the cursor advances past them.
+    }
+  }
+  if (batch.length === 0) return { sent: 0, reason: 'empty_batch' }
+
+  let resp: Response
+  try {
+    resp = await f(`${opts.endpoint}/functions/v1/telemetry-ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'apikey': opts.apiKey },
+      body: JSON.stringify(batch),
+    })
+  } catch {
+    return { sent: 0, reason: 'network_error' }
+  }
+
+  if (!resp.ok) return { sent: 0, reason: 'http_error' }
+
+  let body: { inserted?: number } = {}
+  try { body = await resp.json() } catch { return { sent: 0, reason: 'bad_response' } }
+
+  if (!body.inserted || body.inserted <= 0) return { sent: 0, reason: 'nothing_inserted' }
+
+  const newCursor = cursor + batch.length
+  fs.writeFileSync(opts.cursorPath, String(newCursor))
+  return { sent: batch.length }
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import { Analytics } from '@vercel/analytics/next'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -34,7 +33,6 @@ export default function RootLayout({
     <html lang="en" className="dark">
       <body className="font-sans antialiased bg-[#0a0a1a]">
         {children}
-        <Analytics />
       </body>
     </html>
   )

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,6 @@
     "build:webview": "vite build --config vite.config.webview.ts"
   },
   "dependencies": {
-    "@vercel/analytics": "1.6.1",
     "d3-force": "^3.0.0",
     "next": "16.1.6",
     "react": "19.2.4",


### PR DESCRIPTION
## Summary

Adds first-party opt-out telemetry so we can answer one question: **do people come back after day 1?** Shipping as v0.8.1 (patch bump, non-breaking — disabled users see zero behavioral change).

- `session_start`, `session_end`, `error` events posted every few minutes to a first-party Supabase backend we control
- Captures runtime mix (Claude Code, Codex, or both) and observed model IDs per session — tells us which Anthropic/OpenAI models users actually run without needing a model allowlist we'd have to keep updating
- Opt-out via `AGENT_FLOW_TELEMETRY=false` or `DO_NOT_TRACK=1` (GitHub CLI-style convention). Disabled installs write **nothing** to disk — no `~/.agent-flow/` file, no state leak
- Only the shipped `npx agent-flow-app` binary emits. `pnpm run dev` stays silent on purpose so contributor iterations don't pollute retention math

## What's sent vs never sent

| Sent | Never sent |
|---|---|
| Session count + duration + event count | Prompts, tool calls, tool responses |
| OS / arch / `agent-flow` version | File paths, repo names, branch names |
| Random UUID v4 per install (`installation_id`) | Claude / Codex session IDs, transcript content |
| Distinct model IDs observed (`claude-opus-4-7`, `gpt-5`, etc.) | User name / email / IP / hostname |
| Runtime mode (`claude` / `codex` / `claude,codex`) | Environment variables |
| Error class name on uncaught exceptions | Error messages or stack traces |

Inspect the payload locally with `cat ~/.agent-flow/telemetry/events.jsonl`. The README has a short "Privacy & Telemetry" section with opt-out instructions.

## Architecture

- **Client** (in this PR): buffers events to `~/.agent-flow/telemetry/events.jsonl`, syncs on a staggered schedule (+2s, +2min, +3min, then every 5min) so short sessions don't get dropped. Cursor-tracked + single-flight mutex so repeated Ctrl+C / signal storms can't duplicate events
- **Backend** (separate private repo `pixelbrawlgames/agentflow-analytics`): Supabase edge function validates every event (schema version, length caps, allowed types, timestamp freshness), inserts via service role. RLS denies the publishable key all direct table access
- **Endpoint + publishable key** hardcoded at the top of `scripts/telemetry.ts`. Safe to commit — publishable keys are designed to be public, and every write path is validated

## Removed

- `@vercel/analytics` from `web/` — conflicts with the first-party-only commitment

## Test plan

- [x] `pnpm test` — 24 unit tests pass (sanitizer, sync cursor semantics, telemetry client env-var matrix, install-id persistence)
- [x] `pnpm build:app` — bundle built, `AGENT_FLOW_APP_VERSION` inlined correctly via esbuild `define`
- [x] Live E2E — fresh install, ran `claude` with one prompt, got `{duration_s: 58, event_count: 7, models: "claude-opus-4-7", runtimes: "claude,codex"}` in Supabase. Confirmed exactly 1 `session_start` + 1 `session_end` per process run, zero duplicates despite Ctrl+C spam
- [x] Opt-out paths — `AGENT_FLOW_TELEMETRY=false` and `DO_NOT_TRACK=1` both leave `~/.agent-flow/` completely empty, no events.jsonl, no install-id