### PR TITLE
New model support (Fable 5, Sonnet 5, Opus 4.8, GPT-5.x Codex) + Codex discovery fixes (v0.9.0)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-flow-app",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Real-time visualization of AI agent orchestration — standalone web app",
   "bin": {
     "agent-flow": "dist/app.js"

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.0
+
+- **New model support — Claude Fable 5 / Mythos 5, Sonnet 5, Opus 4.8, GPT-5.x Codex** (#57)
+  - Context window sizing: `fable`/`mythos` family recognized as 1M context (previously fell back to 200k, showing the gauge 5× overfull); `gpt-*` family recognized as 400k as the fallback when Codex doesn't report its own authoritative window. Sonnet 5 / Opus 4.8 already matched the existing family patterns
+  - Cost display: per-model-family blended $/M rates (Fable/Mythos $10/$50, Opus $5/$25, Sonnet $3/$15, Haiku $1/$5, GPT-5.x Codex $1.75/$14) replace the single Sonnet-class rate that was applied to every agent. Agents now carry the detected model ID, and the cost pill, summary panel, and per-tool breakdown all use the owning agent's rate
+- **Codex session discovery fixes** — addresses reports of Codex sessions not appearing
+  - Windows: workspace/cwd matching is now case-insensitive on win32 (VS Code reports `c:\...`, Codex writes `C:\...` — sessions never matched)
+  - Large `session_meta`: the first-line reader now grows up to 1MB instead of a fixed 64KB — newer Codex versions embed full base instructions and AGENTS.md content, which silently broke cwd extraction and skipped the session
+  - Silent cwd mismatch: when recent Codex sessions exist but none ran in the current workspace, a warning now says so (the most common cause: launching `npx agent-flow-app` from a different directory than the Codex session). Warnings are visible without `--verbose`
+- Fix: assistant messages in Codex sessions were labeled "CLAUDE" in the transcript panels and canvas bubbles — the label now follows the session runtime ("CODEX") (#49)
+
 ## 0.8.1
 
 - **Opt-out anonymous usage telemetry** — Agent Flow now tracks whether people come back after day 1 so we can tell whether it's actually useful. Only aggregate session metadata is sent, never prompts, file paths, or code

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-flow",
   "displayName": "Agent Flow",
   "description": "Real-time visualization of Claude Code and Codex agent orchestration",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "publisher": "simon-p",
   "license": "Apache-2.0",
   "repository": {

--- a/extension/src/codex-session-watcher.ts
+++ b/extension/src/codex-session-watcher.ts
@@ -92,22 +92,35 @@ function recentSessionDirs(now: Date): string[] {
  *  UTF-8 safety: `\n` is 0x0a, which never appears as a continuation byte in
  *  a multi-byte UTF-8 sequence (continuation bytes are 0x80–0xBF), so slicing
  *  at the byte-indexed newline is guaranteed to land on a character boundary.
- *  If no newline is found in the first 64KB (pathological session_meta), we
- *  fall back to the full read — JSON.parse will fail on the truncated object
- *  and we'll return null rather than emit a corrupted cwd. */
+ *
+ *  session_meta is typically well under 4KB, but base_instructions (which
+ *  newer Codex versions embed in full, including AGENTS.md content) can push
+ *  it far larger — keep reading in chunks until the first newline, up to a
+ *  1MB cap. Past the cap we give up: JSON.parse fails on the truncated object
+ *  and we return null rather than emit a corrupted cwd. */
 function readSessionCwd(filePath: string): string | null {
+  const CHUNK_SIZE = 65536
+  const MAX_FIRST_LINE = 1048576
   try {
     const fd = fs.openSync(filePath, 'r')
     try {
-      // First line is session_meta; it's typically well under 4KB, but
-      // base_instructions can push it larger. Read a generous chunk.
-      const buf = Buffer.alloc(65536)
-      const read = fs.readSync(fd, buf, 0, buf.length, 0)
-      // indexOf bounded to the filled portion — unwritten bytes are zero and
-      // would never match 0x0a, but an explicit end offset makes this obvious.
-      const firstNewline = buf.subarray(0, read).indexOf(0x0a)
-      const end = firstNewline >= 0 ? firstNewline : read
-      const line = buf.slice(0, end).toString('utf-8')
+      const chunks: Buffer[] = []
+      let total = 0
+      let end = -1
+      while (total < MAX_FIRST_LINE) {
+        const buf = Buffer.alloc(CHUNK_SIZE)
+        const read = fs.readSync(fd, buf, 0, buf.length, total)
+        if (read <= 0) break
+        const filled = buf.subarray(0, read)
+        // indexOf bounded to the filled portion — unwritten bytes are zero and
+        // would never match 0x0a, but an explicit end offset makes this obvious.
+        const newlineAt = filled.indexOf(0x0a)
+        chunks.push(filled)
+        total += read
+        if (newlineAt >= 0) { end = total - read + newlineAt; break }
+      }
+      const data = Buffer.concat(chunks)
+      const line = data.subarray(0, end >= 0 ? end : data.length).toString('utf-8')
       const parsed = JSON.parse(line) as { type?: string; payload?: { cwd?: string } }
       if (parsed.type !== 'session_meta') return null
       return typeof parsed.payload?.cwd === 'string' ? parsed.payload.cwd : null
@@ -122,6 +135,8 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
   private sessions = new Map<string, WatchedCodexSession>()
   private workspacePath: string | null = null
   private scanInterval: NodeJS.Timeout | null = null
+  /** One-shot flag so the cwd-mismatch hint is logged at most once per process. */
+  private cwdMismatchWarned = false
 
   private readonly _onEvent = new TypedEventEmitter<AgentEvent>()
   private readonly _onSessionDetected = new TypedEventEmitter<string>()
@@ -189,6 +204,7 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
 
   private scanForSessions(): void {
     const now = new Date()
+    let skippedByCwd = 0
     for (const dir of recentSessionDirs(now)) {
       if (!fs.existsSync(dir)) continue
 
@@ -221,11 +237,26 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
           const cwd = readSessionCwd(filePath)
           if (cwd === null) continue
           const resolvedCwd = this.resolvePath(cwd)
-          if (!resolvedCwd || !this.pathMatchesWorkspace(resolvedCwd)) continue
+          if (!resolvedCwd || !this.pathMatchesWorkspace(resolvedCwd)) {
+            skippedByCwd++
+            continue
+          }
         }
 
         this.attachSession(filePath, stat)
       }
+    }
+
+    // Recent Codex activity exists but none of it belongs to this workspace —
+    // the #1 reason users see no Codex events. Say so once, loudly enough to
+    // survive the standalone app's default log level.
+    if (skippedByCwd > 0 && this.sessions.size === 0 && !this.cwdMismatchWarned) {
+      this.cwdMismatchWarned = true
+      log.warn(
+        `Found ${skippedByCwd} recent Codex session(s), but none ran in ${this.workspacePath}. ` +
+        `Codex sessions are only shown for the current workspace — launch the visualizer from the ` +
+        `directory where Codex runs (or open that folder in VS Code).`,
+      )
     }
   }
 
@@ -238,10 +269,15 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
     try { return fs.realpathSync(p) } catch { return p }
   }
 
+  /** Windows filesystems are case-insensitive and tools disagree on drive-letter
+   *  case (VS Code reports `c:\...`, Codex writes `C:\...`) — compare folded there. */
   private pathMatchesWorkspace(p: string): boolean {
     if (!this.workspacePath) return true
-    if (p === this.workspacePath) return true
-    return p.startsWith(this.workspacePath + path.sep)
+    const fold = (s: string) => process.platform === 'win32' ? s.toLowerCase() : s
+    const candidate = fold(p)
+    const workspace = fold(this.workspacePath)
+    if (candidate === workspace) return true
+    return candidate.startsWith(workspace + path.sep)
   }
 
   private attachSession(filePath: string, stat: fs.Stats): void {

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -374,7 +374,9 @@ function resolveRuntimeMode(explicit?: RelayRuntimeMode): RelayRuntimeMode {
 export async function createRelay(options: RelayOptions): Promise<Relay> {
   const { workspace } = options
   verbose = options.verbose ?? false
-  if (!verbose) setLogLevel('error')
+  // Keep warnings visible without --verbose — actionable hints (e.g. "Codex
+  // sessions exist but none match this workspace") must reach the user.
+  if (!verbose) setLogLevel('warn')
   if (relayCreated) {
     throw new Error('createRelay() can only be called once per process')
   }

--- a/web/components/agent-visualizer/canvas/draw-bubbles.ts
+++ b/web/components/agent-visualizer/canvas/draw-bubbles.ts
@@ -29,7 +29,8 @@ export function drawMessageBubblesWorld(
       const isThinking = role === 'thinking'
       const bgColor = isThinking ? COLORS.bubbleThinkingBase : role === 'user' ? COLORS.bubbleUserBase : COLORS.bubbleAssistantBase
       const textColor = isThinking ? COLORS.roleThinkingText : role === 'user' ? COLORS.roleUserText : COLORS.roleAssistantText
-      const label = isThinking ? '\uD83D\uDCAD THINKING' : role === 'user' ? 'USER' : 'CLAUDE'
+      const assistantLabel = agent.runtime === 'codex' ? 'CODEX' : 'CLAUDE'
+      const label = isThinking ? '\uD83D\uDCAD THINKING' : role === 'user' ? 'USER' : assistantLabel
 
       // Thinking bubbles: smaller font, tighter spacing, more translucent
       const style = isThinking ? BUBBLE_DRAW.thinking : BUBBLE_DRAW.normal

--- a/web/components/agent-visualizer/canvas/draw-cost.ts
+++ b/web/components/agent-visualizer/canvas/draw-cost.ts
@@ -1,11 +1,23 @@
 import { Agent, ToolCallNode, NODE } from '@/lib/agent-types'
 import { COLORS } from '@/lib/colors'
-import { COST_RATE, COST_DRAW, COST_PANEL, MIN_VISIBLE_OPACITY } from '@/lib/canvas-constants'
+import { COST_RATE, MODEL_FAMILY_COST, COST_DRAW, COST_PANEL, MIN_VISIBLE_OPACITY } from '@/lib/canvas-constants'
 import { formatTokens } from '@/lib/utils'
 import { truncateText } from './draw-misc'
 
-export function agentCost(tokensUsed: number): number {
-  return (tokensUsed / 1_000_000) * COST_RATE
+/** Blended $/M-token rate for a model ID — first matching family wins,
+ *  unknown models fall back to the Sonnet-class rate. */
+export function modelCostRate(model?: string): number {
+  if (model) {
+    const id = model.toLowerCase()
+    for (const { pattern, rate } of MODEL_FAMILY_COST) {
+      if (pattern.test(id)) return rate
+    }
+  }
+  return COST_RATE
+}
+
+export function agentCost(tokensUsed: number, model?: string): number {
+  return (tokensUsed / 1_000_000) * modelCostRate(model)
 }
 
 /** Tool name -> color for mini cost bar */
@@ -38,7 +50,7 @@ export function drawCostLabels(
 
   for (const [, agent] of agents) {
     if (agent.opacity < MIN_VISIBLE_OPACITY) continue
-    const cost = agentCost(agent.tokensUsed)
+    const cost = agentCost(agent.tokensUsed, agent.model)
     if (cost < COST_DRAW.minDisplayCost) continue
 
     const r = agent.isMain ? NODE.radiusMain : NODE.radiusSub
@@ -123,23 +135,25 @@ export function drawCostSummaryPanel(
 
   // Compute totals
   const totalTokens = agentList.reduce((s, a) => s + a.tokensUsed, 0)
-  const totalCost = agentCost(totalTokens)
 
   // Per-agent breakdown sorted by cost desc
   const agentBreakdown = agentList
-    .map(a => ({ name: a.name, tokens: a.tokensUsed, cost: agentCost(a.tokensUsed) }))
+    .map(a => ({ name: a.name, tokens: a.tokensUsed, cost: agentCost(a.tokensUsed, a.model) }))
     .sort((a, b) => b.cost - a.cost)
+  const totalCost = agentBreakdown.reduce((s, a) => s + a.cost, 0)
 
-  // Per-tool-type breakdown
-  const toolBreakdown = new Map<string, number>()
+  // Per-tool-type breakdown, costed at the owning agent's model rate
+  const toolBreakdown = new Map<string, { tokens: number; cost: number }>()
   for (const [, tc] of toolCalls) {
     if (tc.tokenCost) {
-      const key = tc.toolName
-      toolBreakdown.set(key, (toolBreakdown.get(key) || 0) + tc.tokenCost)
+      const entry = toolBreakdown.get(tc.toolName) || { tokens: 0, cost: 0 }
+      entry.tokens += tc.tokenCost
+      entry.cost += agentCost(tc.tokenCost, agents.get(tc.agentId)?.model)
+      toolBreakdown.set(tc.toolName, entry)
     }
   }
   const toolList = Array.from(toolBreakdown.entries())
-    .map(([name, tokens]) => ({ name, tokens, cost: agentCost(tokens) }))
+    .map(([name, { tokens, cost }]) => ({ name, tokens, cost }))
     .sort((a, b) => b.cost - a.cost)
 
   // Panel dimensions — positioned top-right

--- a/web/components/agent-visualizer/chat-panel.tsx
+++ b/web/components/agent-visualizer/chat-panel.tsx
@@ -12,6 +12,7 @@ interface ChatPanelProps {
   agentName: string
   agentState: AgentState
   conversation: ConversationMessage[]
+  runtime?: 'claude' | 'codex'
   onClose: () => void
 }
 
@@ -20,6 +21,7 @@ export function AgentChatPanel({
   agentName,
   agentState,
   conversation,
+  runtime,
   onClose,
 }: ChatPanelProps) {
   const { ref: logRef } = useAutoScroll(conversation.length, visible)
@@ -62,7 +64,7 @@ export function AgentChatPanel({
             </div>
           ) : (
             conversation.map((msg) => (
-              <TranscriptMessage key={msg.id} message={msg} />
+              <TranscriptMessage key={msg.id} message={msg} assistantLabel={runtime === 'codex' ? 'CODEX' : 'CLAUDE'} />
             ))
           )}
         </div>

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -210,6 +210,14 @@ export function AgentVisualizer() {
   const selectedAgent = selection.selectedAgentId ? agents.get(selection.selectedAgentId) : null
   const selectedConversation = selection.selectedAgentId ? (conversations.get(selection.selectedAgentId) || []) : []
 
+  // Session runtime — drives the assistant label (CLAUDE vs CODEX) in transcript panels
+  const sessionRuntime = useMemo(() => {
+    for (const a of agents.values()) {
+      if (a.runtime === 'codex') return 'codex' as const
+    }
+    return 'claude' as const
+  }, [agents])
+
   // Session-wide conversation (all agents merged chronologically)
   // Only compute when the transcript panel is visible to avoid O(n log n) sort every frame
   const sessionConversation = useMemo(() => {
@@ -327,6 +335,7 @@ export function AgentVisualizer() {
         agentName={selectedAgent?.name ?? ''}
         agentState={selectedAgent?.state ?? 'idle'}
         conversation={selectedConversation}
+        runtime={selectedAgent?.runtime ?? sessionRuntime}
         onClose={selection.clearAgent}
       />
 
@@ -378,6 +387,7 @@ export function AgentVisualizer() {
       <SessionTranscriptPanel
         visible={showTranscript}
         conversation={sessionConversation}
+        runtime={sessionRuntime}
         onClose={() => setShowTranscript(false)}
       />
 

--- a/web/components/agent-visualizer/session-transcript-panel.tsx
+++ b/web/components/agent-visualizer/session-transcript-panel.tsx
@@ -18,12 +18,14 @@ const TRANSCRIPT_INITIAL_VIEWPORT = 400
 interface TranscriptPanelProps {
   visible: boolean
   conversation: ConversationMessage[]
+  runtime?: 'claude' | 'codex'
   onClose: () => void
 }
 
 export function SessionTranscriptPanel({
   visible,
   conversation,
+  runtime,
   onClose,
 }: TranscriptPanelProps) {
   const [searchQuery, setSearchQuery] = useState('')
@@ -146,7 +148,7 @@ export function SessionTranscriptPanel({
                     ref={(el) => itemMeasureRef(msg.id, el)}
                     style={{ marginBottom: TRANSCRIPT_GAP }}
                   >
-                    <TranscriptMessage message={msg} searchQuery={searchQuery} />
+                    <TranscriptMessage message={msg} searchQuery={searchQuery} assistantLabel={runtime === 'codex' ? 'CODEX' : 'CLAUDE'} />
                   </div>
                 ))}
               </div>

--- a/web/components/agent-visualizer/transcript-message.tsx
+++ b/web/components/agent-visualizer/transcript-message.tsx
@@ -21,7 +21,7 @@ export function HighlightText({ text, query }: { text: string; query?: string })
   )
 }
 
-export function TranscriptMessage({ message, compact = false, searchQuery }: { message: ConversationMessage; compact?: boolean; searchQuery?: string }) {
+export function TranscriptMessage({ message, compact = false, searchQuery, assistantLabel = 'CLAUDE' }: { message: ConversationMessage; compact?: boolean; searchQuery?: string; assistantLabel?: string }) {
   const [expanded, setExpanded] = useState(false)
 
   switch (message.type) {
@@ -50,7 +50,7 @@ export function TranscriptMessage({ message, compact = false, searchQuery }: { m
             border: `1px solid ${COLORS.holoBorder08}`,
           }}
         >
-          <div className="text-[9px] mb-1 font-semibold tracking-wider" style={{ color: COLORS.assistantLabel }}>CLAUDE</div>
+          <div className="text-[9px] mb-1 font-semibold tracking-wider" style={{ color: COLORS.assistantLabel }}>{assistantLabel}</div>
           <div style={{ color: COLORS.assistantText }} className="whitespace-pre-wrap break-words">
             <HighlightText text={compact ? message.content.slice(0, 200) + (message.content.length > 200 ? '...' : '') : message.content} query={searchQuery} />
           </div>

--- a/web/hooks/simulation/handle-agent-events.ts
+++ b/web/hooks/simulation/handle-agent-events.ts
@@ -29,7 +29,8 @@ export function handleAgentSpawn(
       ...existing,
       state: 'idle',
       ...(task ? { task } : {}),
-      ...(model ? { tokensMax: ctx.getContextWindowSize(model) } : {}),
+      ...(model ? { model, tokensMax: ctx.getContextWindowSize(model) } : {}),
+      ...(runtime ? { runtime } : {}),
     })
     return
   }
@@ -81,6 +82,7 @@ export function handleAgentSpawn(
     x, y, vx: 0, vy: 0,
     pinned: false, isMain,
     ...(runtime ? { runtime } : {}),
+    ...(model ? { model } : {}),
     task,
     spawnTime: currentTime,
     opacity: 0, scale: 0.3,
@@ -190,6 +192,7 @@ export function handleModelDetected(
   if (agent) {
     state.agents.set(agentName, {
       ...agent,
+      model,
       tokensMax: ctx.getContextWindowSize(model),
     })
   }

--- a/web/lib/agent-types.ts
+++ b/web/lib/agent-types.ts
@@ -31,6 +31,9 @@ export interface Agent {
   /** Which agent runtime produced this agent — used to pick the brand logo.
    *  Optional for forward compat with events that don't carry it (defaults to 'claude'). */
   runtime?: 'claude' | 'codex'
+  /** Model ID last reported for this agent (agent_spawn / model_detected).
+   *  Drives context-window sizing and the per-family cost rate. */
+  model?: string
   currentTool?: string
   task?: string
   spawnTime: number

--- a/web/lib/canvas-constants.ts
+++ b/web/lib/canvas-constants.ts
@@ -3,8 +3,11 @@
 /** Context window size by model family. Patterns are checked in order;
  *  first match wins. Matched against lower-cased model IDs. */
 export const MODEL_FAMILY_CONTEXT: ReadonlyArray<{ pattern: RegExp; size: number }> = [
-  { pattern: /(opus|sonnet)-\d/, size: 1_000_000 },
+  { pattern: /(opus|sonnet|fable|mythos)-\d/, size: 1_000_000 },
   { pattern: /haiku-\d/, size: 200_000 },
+  // Codex/GPT models. Fallback only — Codex normally reports its own
+  // authoritative window via event_msg.token_count.info.model_context_window.
+  { pattern: /gpt-\d/, size: 400_000 },
 ]
 /** Used when no family pattern matches (unknown model). */
 export const DEFAULT_CONTEXT_SIZE = 200_000
@@ -162,7 +165,19 @@ export function getDiscoveryCardDimensions(label: string, contentLines: string[]
 
 export const TOOL_MAX_CARD_W = 160
 
-/** Blended $/M-token rate for Sonnet-class models */
+/** Blended $/M-token rate by model family (0.75 × input + 0.25 × output
+ *  per-MTok pricing, the same weighting the original Sonnet-class rate used).
+ *  Patterns are checked in order; first match wins. Matched against
+ *  lower-cased model IDs. */
+export const MODEL_FAMILY_COST: ReadonlyArray<{ pattern: RegExp; rate: number }> = [
+  { pattern: /(fable|mythos)-\d/, rate: 20 }, // $10 in / $50 out
+  { pattern: /opus-\d/, rate: 10 },           // $5 in / $25 out
+  { pattern: /sonnet-\d/, rate: 6 },          // $3 in / $15 out
+  { pattern: /haiku-\d/, rate: 2 },           // $1 in / $5 out
+  { pattern: /gpt-\d/, rate: 5 },             // gpt-5.3-codex: $1.75 in / $14 out
+]
+
+/** Blended $/M-token fallback rate for unknown models (Sonnet-class) */
 export const COST_RATE = 6
 
 // ─── Agent drawing constants ────────────────────────────────────────────────


### PR DESCRIPTION
## New model support (#57)

- **Context window sizing** — `fable`/`mythos` model families are now recognized as 1M-context (Fable 5 previously fell through to the 200k default, rendering the context gauge 5× overfull). `gpt-*` models get a 400k fallback; Codex's own authoritative `model_context_window` still takes priority when reported. Sonnet 5 / Opus 4.8 already matched the existing family patterns.
- **Per-model cost rates** — replaces the single Sonnet-class blended rate that was applied to every agent. Blended $/M rates per family (0.75×input + 0.25×output, same weighting the old rate implied): Fable/Mythos $10/$50, Opus $5/$25, Sonnet $3/$15, Haiku $1/$5, GPT-5.3-Codex $1.75/$14. Agents now carry the detected model ID from `agent_spawn`/`model_detected`; the cost pill, summary panel, and per-tool breakdown all use the owning agent's rate.

## Codex session discovery fixes

Addresses reports of Codex sessions not appearing:

- **Windows cwd matching** — VS Code reports `c:\...`, Codex writes `C:\...`; the exact-prefix workspace match never succeeded, so Windows users got zero Codex sessions. Matching is now case-folded on win32.
- **Large `session_meta`** — the first-line reader capped at 64KB; newer Codex versions embed full base instructions + AGENTS.md there, which silently broke cwd extraction and skipped the session. It now grows in chunks up to 1MB.
- **Silent workspace mismatch** — when recent Codex sessions exist but none ran in the current workspace (the most common cause: launching `npx agent-flow-app` from a different directory than the Codex session), a warning now says so. Relay warnings are visible without `--verbose`.

## Fixes #49

Assistant messages in Codex sessions were labeled "CLAUDE" in the transcript panels and canvas bubbles — the label now follows the session runtime ("CODEX").

## Release prep

- Version bumped to 0.9.0 (extension + app), CHANGELOG entry added.
- Extension typecheck, web typecheck, and all 52 tests pass; vsix and app bundle build cleanly.
