### PR TITLE
Fix Windows Claude Code session discovery — case-insensitive project-dir matching (v0.9.1)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-flow-app",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Real-time visualization of AI agent orchestration — standalone web app",
   "bin": {
     "agent-flow": "dist/app.js"

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.1
+
+- Fix: Claude Code session discovery on Windows — workspace-to-project-dir matching is now case-insensitive on win32 (#57, part of #4)
+  - VS Code reports drive letters lowercase (`c:\...`) while Claude Code encodes them uppercase (`C--...`), so the encoded-directory lookup, the subfolder-session prefix check, and the cwd containment check could all silently miss — no sessions appeared at all
+  - The workspace project dir is now resolved to its actual on-disk casing at startup, and all path comparisons are case-folded on Windows (matching the Codex-side fix from 0.9.0)
+
 ## 0.9.0
 
 - **New model support — Claude Fable 5 / Mythos 5, Sonnet 5, Opus 4.8, GPT-5.x Codex** (#57)

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-flow",
   "displayName": "Agent Flow",
   "description": "Real-time visualization of Claude Code and Codex agent orchestration",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "publisher": "simon-p",
   "license": "Apache-2.0",
   "repository": {

--- a/extension/src/fs-utils.ts
+++ b/extension/src/fs-utils.ts
@@ -49,3 +49,10 @@ export function readNewFileLines(
   const lines = parts.filter(Boolean)
   return { lines, newSize: stat.size, tail }
 }
+
+/** Case-fold a path string for comparison on Windows, where the filesystem is
+ *  case-insensitive and tools disagree on drive-letter case (VS Code reports
+ *  `c:\...`, Claude Code and most shells report `C:\...`). Identity elsewhere. */
+export function foldPathCase(p: string): string {
+  return process.platform === 'win32' ? p.toLowerCase() : p
+}

--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -9,7 +9,7 @@ import {
 } from './constants'
 import type { AgentSessionWatcher, SessionLifecycleEvent } from './session-runtime'
 import { TranscriptParser } from './transcript-parser'
-import { readNewFileLines } from './fs-utils'
+import { readNewFileLines, foldPathCase } from './fs-utils'
 import { handlePermissionDetection } from './permission-detection'
 import { scanSubagentsDir, readSubagentNewLines } from './subagent-watcher'
 import { createLogger } from './logger'
@@ -138,15 +138,13 @@ export class SessionWatcher implements AgentSessionWatcher {
       this.resolvedWorkspace = resolved
 
       // Try the resolved encoding first; fall back to unresolved if the directory doesn't exist
-      // (handles edge cases where Claude Code didn't resolve symlinks the same way)
-      const resolvedDir = path.join(CLAUDE_DIR, encoded)
-      if (fs.existsSync(resolvedDir)) {
-        this.workspacePath = encoded
-      } else {
-        const unresolvedEncoded = workspaceFolder.replace(/[^a-zA-Z0-9]/g, '-')
-        const unresolvedDir = path.join(CLAUDE_DIR, unresolvedEncoded)
-        this.workspacePath = fs.existsSync(unresolvedDir) ? unresolvedEncoded : encoded
-      }
+      // (handles edge cases where Claude Code didn't resolve symlinks the same way).
+      // findProjectDirName returns the on-disk casing, so downstream string
+      // comparisons against readdir results stay exact.
+      const unresolvedEncoded = workspaceFolder.replace(/[^a-zA-Z0-9]/g, '-')
+      this.workspacePath = this.findProjectDirName(encoded)
+        ?? this.findProjectDirName(unresolvedEncoded)
+        ?? encoded
       log.info(`Starting — scoped to project: ${this.workspacePath}`)
     } else {
       log.info('Starting — no workspace, scanning all projects')
@@ -209,6 +207,23 @@ export class SessionWatcher implements AgentSessionWatcher {
     } catch (err) { log.debug('Dir watch failed (may not exist yet):', err) }
   }
 
+  /** Find the actual on-disk project dir name under CLAUDE_DIR for an encoded
+   *  workspace path. On Windows the lookup is case-insensitive (VS Code reports
+   *  `c:\...` while Claude Code encodes `C--...`) and returns the real casing.
+   *  Returns null when no matching directory exists. */
+  private findProjectDirName(encoded: string): string | null {
+    if (process.platform !== 'win32') {
+      return fs.existsSync(path.join(CLAUDE_DIR, encoded)) ? encoded : null
+    }
+    try {
+      const folded = encoded.toLowerCase()
+      for (const entry of fs.readdirSync(CLAUDE_DIR, { withFileTypes: true })) {
+        if (entry.isDirectory() && entry.name.toLowerCase() === folded) return entry.name
+      }
+    } catch { /* CLAUDE_DIR may not exist yet */ }
+    return null
+  }
+
   /** Check whether a project dir contains sessions running under the workspace.
    *  The encoded dir name is lossy (hyphens and path separators both become -),
    *  so instead of trying to decode it, we read the cwd from the JSONL files
@@ -217,7 +232,8 @@ export class SessionWatcher implements AgentSessionWatcher {
   private isContainedProject(encodedDirName: string): boolean {
     if (!this.workspacePath || !this.resolvedWorkspace) return false
     // Quick prefix check to avoid reading files from obviously unrelated dirs
-    if (!encodedDirName.startsWith(this.workspacePath + '-')) return false
+    // (case-folded on Windows — encodings from different tools disagree on case)
+    if (!foldPathCase(encodedDirName).startsWith(foldPathCase(this.workspacePath) + '-')) return false
 
     const cached = this.containedProjectCache.get(encodedDirName)
     if (cached !== undefined) return cached
@@ -231,6 +247,8 @@ export class SessionWatcher implements AgentSessionWatcher {
 
   /** Read JSONL files in a project dir to find the cwd and check containment. */
   private readCwdFromProjectDir(encodedDirName: string): boolean {
+    if (!this.resolvedWorkspace) return false
+    const workspaceFolded = foldPathCase(this.resolvedWorkspace)
     const dirPath = path.join(CLAUDE_DIR, encodedDirName)
     try {
       const files = fs.readdirSync(dirPath)
@@ -250,8 +268,9 @@ export class SessionWatcher implements AgentSessionWatcher {
               if (typeof entry.cwd === 'string') {
                 let cwd = entry.cwd
                 try { cwd = fs.realpathSync(cwd) } catch { /* use as-is */ }
-                return cwd === this.resolvedWorkspace
-                  || cwd.startsWith(this.resolvedWorkspace + path.sep)
+                const cwdFolded = foldPathCase(cwd)
+                return cwdFolded === workspaceFolded
+                  || cwdFolded.startsWith(workspaceFolded + path.sep)
               }
             } catch { /* malformed line, try next */ }
           }

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -11,7 +11,7 @@ import * as os from 'os'
 import { HookServer } from '../extension/src/hook-server'
 import { AgentEvent, SessionInfo, WatchedSession } from '../extension/src/protocol'
 import { TranscriptParser } from '../extension/src/transcript-parser'
-import { readNewFileLines } from '../extension/src/fs-utils'
+import { readNewFileLines, foldPathCase } from '../extension/src/fs-utils'
 import { scanSubagentsDir, readSubagentNewLines } from '../extension/src/subagent-watcher'
 import { handlePermissionDetection } from '../extension/src/permission-detection'
 import { CodexSessionWatcher } from '../extension/src/codex-session-watcher'
@@ -274,19 +274,22 @@ function scanForActiveSessions(workspace: string) {
   const encoded = resolved.replace(/[^a-zA-Z0-9]/g, '-')
 
   const dirsToScan: string[] = []
-  const projectDir = path.join(CLAUDE_DIR, encoded)
-  if (fs.existsSync(projectDir)) dirsToScan.push(projectDir)
-
+  // Case-folded on Windows — VS Code/shells report `c:\...` while Claude Code
+  // encodes `C--...`, so exact string matching never found the project dir there.
+  const encodedFolded = foldPathCase(encoded)
   try {
     for (const dir of fs.readdirSync(CLAUDE_DIR, { withFileTypes: true })) {
       if (!dir.isDirectory()) continue
-      const fullPath = path.join(CLAUDE_DIR, dir.name)
-      if (fullPath === projectDir) continue
-      if (dir.name.startsWith(encoded + '-')) {
-        dirsToScan.push(fullPath)
+      const nameFolded = foldPathCase(dir.name)
+      if (nameFolded === encodedFolded || nameFolded.startsWith(encodedFolded + '-')) {
+        dirsToScan.push(path.join(CLAUDE_DIR, dir.name))
       }
     }
-  } catch {}
+  } catch {
+    // readdir failed — fall back to the exact-match dir if it exists
+    const projectDir = path.join(CLAUDE_DIR, encoded)
+    if (fs.existsSync(projectDir)) dirsToScan.push(projectDir)
+  }
 
   for (const dirPath of dirsToScan) {
     try {


### PR DESCRIPTION
## Problem

On Windows, Claude Code sessions were often not discovered at all — the likely remaining root cause behind #57 (and part of #4).

VS Code reports workspace paths with a lowercase drive letter (`c:\Users\...`) while Claude Code encodes project dirs from the shell's uppercase form (`C--Users-...`). NTFS being case-insensitive masked this for `fs.existsSync`/`fs.watch`, but three **string** comparisons silently missed:

- the encoded project-dir lookup in `SessionWatcher.start()`
- the subfolder-session prefix check in `isContainedProject()`
- the cwd containment check in `readCwdFromProjectDir()`
- the relay's `scanForActiveSessions()` equivalents (standalone `npx agent-flow-app` path)

## Fix

- Resolve the workspace project dir to its **actual on-disk casing** at startup (`findProjectDirName`), so downstream exact comparisons against `readdir` results are correct
- Case-fold all remaining path comparisons on win32 via a shared `foldPathCase` helper — the same approach as the Codex-side fix in 0.9.0
- Behavior on macOS/Linux is unchanged (`foldPathCase` is identity there); verified the relay scanner still matches real project dirs on macOS

## Release prep

- Version 0.9.1, CHANGELOG entry
- Extension typecheck clean, 28 + 24 tests pass, relay/app/vsix build cleanly