### PR TITLE
fix: prevent system-injected content from becoming agent display name

### DIFF
--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -197,10 +197,13 @@ export function resolveSubagentChildName(input: Record<string, unknown>): string
   return String(input.description || input.subagent_type || 'subagent').slice(0, CHILD_NAME_MAX)
 }
 
-/** Prefixes that identify system-injected content (not real user messages)
- *  for Claude Code. Codex has its own extraction in codex-rollout-parser.ts
- *  because the injection format is structurally different (e.g. real prompts
- *  wrapped inside a "# Context from my IDE setup:" block, reachable via the
+/** Prefixes that identify system-injected content (not real user messages).
+ *  Used by both Claude Code (transcript-parser.ts) and Codex
+ *  (codex-rollout-parser.ts extractCodexUserText), so additions here
+ *  widen filtering for both runtimes.
+ *  Codex also has its own extraction logic because the injection format
+ *  is structurally different (e.g. real prompts wrapped inside a
+ *  "# Context from my IDE setup:" block, reachable via the
  *  "## My request for Codex:" marker). */
 export const SYSTEM_CONTENT_PREFIXES = [
   'This session is being continued',
@@ -210,4 +213,6 @@ export const SYSTEM_CONTENT_PREFIXES = [
   '<command-name',
   '<system_instruction',
   '<task-notification',
+  '<local-command-stdout',
+  '<local-command-caveat',
 ] as const

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -208,4 +208,6 @@ export const SYSTEM_CONTENT_PREFIXES = [
   '<system-reminder',
   '<available-deferred-tools',
   '<command-name',
+  '<system_instruction',
+  '<task-notification',
 ] as const

--- a/web/hooks/simulation/handle-message-events.ts
+++ b/web/hooks/simulation/handle-message-events.ts
@@ -3,6 +3,16 @@ import type { ConversationMessage } from './types'
 import { appendConversation, asString, asNumber, LABEL_LEN_NAME, LABEL_LEN_TASK, LABEL_LEN_BUBBLE, MAX_BUBBLES } from './types'
 import type { MutableEventState } from './process-event'
 
+const SYSTEM_CONTENT_PREFIXES = [
+  'This session is being continued',
+  '<ide_',
+  '<system-reminder',
+  '<available-deferred-tools',
+  '<command-name',
+  '<system_instruction',
+  '<task-notification',
+]
+
 export function handleMessage(
   payload: Record<string, unknown>,
   currentTime: number,
@@ -19,7 +29,8 @@ export function handleMessage(
     'assistant'
 
   // Rename main agent to the first user message (more recognizable than "orchestrator")
-  if (role === 'user') {
+  const isSystemContent = SYSTEM_CONTENT_PREFIXES.some(prefix => content.startsWith(prefix))
+  if (role === 'user' && !isSystemContent) {
     const msgAgentForName = state.agents.get(agentName)
     if (msgAgentForName && msgAgentForName.isMain && msgAgentForName.name === agentName) {
       const shortName = content.slice(0, LABEL_LEN_NAME).replace(/\n/g, ' ').trim()

--- a/web/hooks/simulation/handle-message-events.ts
+++ b/web/hooks/simulation/handle-message-events.ts
@@ -3,17 +3,6 @@ import type { ConversationMessage } from './types'
 import { appendConversation, asString, asNumber, LABEL_LEN_NAME, LABEL_LEN_TASK, LABEL_LEN_BUBBLE, MAX_BUBBLES } from './types'
 import type { MutableEventState } from './process-event'
 
-// Keep in sync with extension/src/constants.ts SYSTEM_CONTENT_PREFIXES
-const SYSTEM_CONTENT_PREFIXES = [
-  'This session is being continued',
-  '<ide_',
-  '<system-reminder',
-  '<available-deferred-tools',
-  '<command-name',
-  '<system_instruction',
-  '<task-notification',
-]
-
 export function handleMessage(
   payload: Record<string, unknown>,
   currentTime: number,
@@ -30,8 +19,7 @@ export function handleMessage(
     'assistant'
 
   // Rename main agent to the first user message (more recognizable than "orchestrator")
-  const isSystemContent = SYSTEM_CONTENT_PREFIXES.some(prefix => content.startsWith(prefix))
-  if (role === 'user' && !isSystemContent) {
+  if (role === 'user') {
     const msgAgentForName = state.agents.get(agentName)
     if (msgAgentForName && msgAgentForName.isMain && msgAgentForName.name === agentName) {
       const shortName = content.slice(0, LABEL_LEN_NAME).replace(/\n/g, ' ').trim()

--- a/web/hooks/simulation/handle-message-events.ts
+++ b/web/hooks/simulation/handle-message-events.ts
@@ -3,6 +3,7 @@ import type { ConversationMessage } from './types'
 import { appendConversation, asString, asNumber, LABEL_LEN_NAME, LABEL_LEN_TASK, LABEL_LEN_BUBBLE, MAX_BUBBLES } from './types'
 import type { MutableEventState } from './process-event'
 
+// Keep in sync with extension/src/constants.ts SYSTEM_CONTENT_PREFIXES
 const SYSTEM_CONTENT_PREFIXES = [
   'This session is being continued',
   '<ide_',


### PR DESCRIPTION
Sessions starting with system-injected content (e.g. Conductor's <system_instruction>) had their agent node and session label set to the injected text instead of the actual user prompt.

Added `<system_instruction>`, `<task-notification>`, `<local-command-stdout>`, and `<local-command-caveat>` to SYSTEM_CONTENT_PREFIXES in extension/src/constants.ts. The extension-side isSystemInjectedContent already gates all message emission, so no web-side filtering was needed. Updated the doc comment to clarify that extractCodexUserText also consults this list.