### PR TITLE
fix: show CODEX label for codex assistant messages in message feed panel

### DIFF
--- a/web/components/agent-visualizer/message-feed-panel.tsx
+++ b/web/components/agent-visualizer/message-feed-panel.tsx
@@ -288,6 +288,7 @@ export function MessageFeedPanel({
                       showAgent={activeTab === 'all'}
                       isSelected={selectedAgentId === msg.agentId}
                       onClick={() => { onAgentClick(msg.agentId); setExpanded(false) }}
+                      runtime={agents.get(msg.agentId)?.runtime}
                     />
                   </div>
                 ))}
@@ -332,16 +333,18 @@ function TabButton({ label, active, onClick, color, hasUnread }: {
 
 // ── Message Row ──
 
-function MessageRow({ message, agentId, agentName, showAgent, isSelected, onClick }: {
+function MessageRow({ message, agentId, agentName, showAgent, isSelected, onClick, runtime }: {
   message: ConversationMessage
   agentId: string
   agentName: string
   showAgent: boolean
   isSelected: boolean
   onClick: () => void
+  runtime?: Agent['runtime']
 }) {
   const [expanded, setExpanded] = useState(false)
   const role = ROLE_COLORS[message.type] ?? ROLE_COLORS.assistant
+  const roleLabel = message.type === 'assistant' && runtime === 'codex' ? 'CODEX' : role.label
   const isLong = message.content.length > MESSAGE_TRUNCATE_MAX
   const displayText = expanded || !isLong ? message.content : message.content.slice(0, MESSAGE_TRUNCATE_MAX) + '...'
 
@@ -357,7 +360,7 @@ function MessageRow({ message, agentId, agentName, showAgent, isSelected, onClic
       {/* Header row */}
       <div className="flex items-center gap-1.5 mb-0.5">
         <span className="text-[9px] font-mono font-semibold" style={{ color: role.text + '90' }}>
-          {role.label}
+          {roleLabel}
         </span>
         {showAgent && (
           <span className="text-[9px] font-mono" style={{ color: COLORS.textMuted }}>


### PR DESCRIPTION
## What does this PR do?

Fixes the message feed panel mislabeling Codex assistant messages as CLAUDE. `MessageRow` rendered the hardcoded label from `ROLE_COLORS.assistant` regardless of runtime; it now derives the label from the message agent's `runtime`, matching the chat panel and transcript behavior. Spotted while triaging #50.

## How to test

1. Run `pnpm run dev` and start a Codex session.
2. Open the message feed panel (top-left) and expand it.
3. Verify assistant messages from Codex agents are labeled CODEX; Claude sessions still show CLAUDE.
4. `pnpm run build:web` and `npx tsc --noEmit` in `web/` pass.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)