### PR TITLE
ci: run tests and typechecks on push and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Root tests (scripts, app)
+        run: pnpm test
+
+      - name: Extension tests
+        run: pnpm --dir extension test
+
+      - name: Extension typecheck
+        run: pnpm --filter agent-flow run lint
+
+      - name: Web typecheck
+        run: pnpm --dir web exec tsc --noEmit


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Actions workflow running on pushes to main and on PRs:

- root `pnpm test` (scripts/ and app/ suites)
- `pnpm --dir extension test` (extension suite, previously manual-only)
- extension `tsc --noEmit`
- web `tsc --noEmit`

Note `scripts/` is not covered by any tsc project, so type errors there remain invisible; the runtime tests are the guard for now.

## How to test

1. All four commands verified passing locally on current main.
2. The workflow's own run on this PR is the live test — see the checks below (passed in 24s).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)