### PR TITLE
refactor: single source of truth for Claude model families

### DIFF
--- a/scripts/format-model-name.test.ts
+++ b/scripts/format-model-name.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import { strict as assert } from 'node:assert'
 import { formatModelName } from '../web/lib/utils'
+import { CLAUDE_FAMILIES } from '../web/lib/canvas-constants'
 
 test('formats new Claude model ids', () => {
   assert.equal(formatModelName('claude-sonnet-4-20250514'), 'Sonnet 4')
@@ -34,4 +35,16 @@ test('formats GPT model ids', () => {
 
 test('falls back to stripped base model id for unknown formats', () => {
   assert.equal(formatModelName('custom-model-20250101'), 'custom-model')
+})
+
+test('matches case-insensitively, preserving fallback case', () => {
+  assert.equal(formatModelName('CLAUDE-3-5-SONNET-20241022'), 'Sonnet 3.5')
+  assert.equal(formatModelName('US.ANTHROPIC.CLAUDE-OPUS-4-1-20250805-V1:0'), 'Opus 4.1')
+  assert.equal(formatModelName('Custom-Model-20250101'), 'Custom-Model')
+})
+
+test('every CLAUDE_FAMILIES entry is formattable', () => {
+  for (const f of CLAUDE_FAMILIES) {
+    assert.equal(formatModelName(`claude-${f.name}-9-20990101`), `${f.name[0].toUpperCase()}${f.name.slice(1)} 9`)
+  }
 })

--- a/web/lib/canvas-constants.ts
+++ b/web/lib/canvas-constants.ts
@@ -1,10 +1,24 @@
-// ─── Model context sizes ────────────────────────────────────────────────────
+// ─── Model families ──────────────────────────────────────────────────────────
+
+/** Single source of truth for Claude model families. Display names
+ *  (formatModelName in utils.ts), context-window sizes, and cost rates all
+ *  derive from this table — add new families here and nowhere else.
+ *  Rates are blended $/M-token (0.75 × input + 0.25 × output per-MTok). */
+export const CLAUDE_FAMILIES: ReadonlyArray<{ name: string; context: number; rate: number }> = [
+  { name: 'fable',  context: 1_000_000, rate: 20 }, // $10 in / $50 out
+  { name: 'mythos', context: 1_000_000, rate: 20 }, // $10 in / $50 out
+  { name: 'opus',   context: 1_000_000, rate: 10 }, // $5 in / $25 out
+  { name: 'sonnet', context: 1_000_000, rate: 6 },  // $3 in / $15 out
+  { name: 'haiku',  context: 200_000,   rate: 2 },  // $1 in / $5 out
+]
+
+/** Regex alternation fragment of all Claude family names (e.g. 'fable|mythos|…'). */
+export const CLAUDE_FAMILY_ALTERNATION = CLAUDE_FAMILIES.map(f => f.name).join('|')
 
 /** Context window size by model family. Patterns are checked in order;
  *  first match wins. Matched against lower-cased model IDs. */
 export const MODEL_FAMILY_CONTEXT: ReadonlyArray<{ pattern: RegExp; size: number }> = [
-  { pattern: /(opus|sonnet|fable|mythos)-\d/, size: 1_000_000 },
-  { pattern: /haiku-\d/, size: 200_000 },
+  ...CLAUDE_FAMILIES.map(f => ({ pattern: new RegExp(`${f.name}-\\d`), size: f.context })),
   // Codex/GPT models. Fallback only — Codex normally reports its own
   // authoritative window via event_msg.token_count.info.model_context_window.
   { pattern: /gpt-\d/, size: 400_000 },
@@ -167,14 +181,11 @@ export const TOOL_MAX_CARD_W = 160
 
 /** Blended $/M-token rate by model family (0.75 × input + 0.25 × output
  *  per-MTok pricing, the same weighting the original Sonnet-class rate used).
- *  Patterns are checked in order; first match wins. Matched against
- *  lower-cased model IDs. */
+ *  Claude rates derive from CLAUDE_FAMILIES. Patterns are checked in order;
+ *  first match wins. Matched against lower-cased model IDs. */
 export const MODEL_FAMILY_COST: ReadonlyArray<{ pattern: RegExp; rate: number }> = [
-  { pattern: /(fable|mythos)-\d/, rate: 20 }, // $10 in / $50 out
-  { pattern: /opus-\d/, rate: 10 },           // $5 in / $25 out
-  { pattern: /sonnet-\d/, rate: 6 },          // $3 in / $15 out
-  { pattern: /haiku-\d/, rate: 2 },           // $1 in / $5 out
-  { pattern: /gpt-\d/, rate: 5 },             // gpt-5.3-codex: $1.75 in / $14 out
+  ...CLAUDE_FAMILIES.map(f => ({ pattern: new RegExp(`${f.name}-\\d`), rate: f.rate })),
+  { pattern: /gpt-\d/, rate: 5 }, // gpt-5.3-codex: $1.75 in / $14 out
 ]
 
 /** Blended $/M-token fallback rate for unknown models (Sonnet-class) */

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -1,3 +1,5 @@
+import { CLAUDE_FAMILY_ALTERNATION } from './canvas-constants'
+
 /** Convert a 0–1 alpha value to a two-character hex string (e.g. 0.5 → '80') */
 export function alphaHex(alpha: number): string {
   return Math.floor(alpha * 255).toString(16).padStart(2, '0')
@@ -13,16 +15,16 @@ export function truncatePath(path: string, segments = 3): string {
   return path.split('/').slice(-segments).join('/')
 }
 
-const PROVIDER_PREFIX = /^[a-z]+\.anthropic\./
-const VERSION_SUFFIX = /-v\d+:\d+$/
+const PROVIDER_PREFIX = /^[a-z]+\.anthropic\./i
+const VERSION_SUFFIX = /-v\d+:\d+$/i
 const DATE_STAMP = /-\d{8}(?=$|-)/
 
-const CLAUDE_NEW = /claude-(sonnet|opus|haiku|fable|mythos)-(\d+)(?:-(\d+))?/
-const CLAUDE_LEGACY = /claude-(\d+)(?:-(\d+))?-(sonnet|opus|haiku|fable|mythos)/
-const GPT = /gpt-(\S+?)(?:-\d{4}-\d{2}-\d{2})?$/
+const CLAUDE_NEW = new RegExp(`claude-(${CLAUDE_FAMILY_ALTERNATION})-(\\d+)(?:-(\\d+))?`, 'i')
+const CLAUDE_LEGACY = new RegExp(`claude-(\\d+)(?:-(\\d+))?-(${CLAUDE_FAMILY_ALTERNATION})`, 'i')
+const GPT = /gpt-(\S+?)(?:-\d{4}-\d{2}-\d{2})?$/i
 
 function claudeLabel(family: string, major: string, minor?: string): string {
-  const name = family[0].toUpperCase() + family.slice(1)
+  const name = family[0].toUpperCase() + family.slice(1).toLowerCase()
   return minor ? `${name} ${major}.${minor}` : `${name} ${major}`
 }
 


### PR DESCRIPTION
## What does this PR do?

Consolidates the Claude family list that existed in three places (the `formatModelName` regexes, `MODEL_FAMILY_CONTEXT`, and `MODEL_FAMILY_COST`) into one `CLAUDE_FAMILIES` table in `canvas-constants.ts` that drives display names, context windows, and cost rates. Also makes the formatter match case-insensitively, consistent with the tables' documented lower-cased matching. No behavior change for existing model IDs. Follow-up promised in #60.

## How to test

1. `pnpm test` — includes two new tests: case-insensitive matching, and a loop asserting every `CLAUDE_FAMILIES` entry is formattable.
2. `pnpm run build:web`.
3. In the visualizer, model labels, context bars, and cost display are unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)