### PR TITLE
feat(dev): target sessions outside workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ git clone https://github.com/patoles/agent-flow.git
 cd agent-flow
 pnpm i
 pnpm run setup      # configure Claude Code hooks (one-time)
-pnpm run dev        # start the web app + event relay
+pnpm dev            # start the web app + event relay for this repository
+pnpm dev -- /path/to/workspace  # watch a specific workspace instead
 ```
 
 Open http://localhost:3000 and start a Claude Code session in another terminal — events will stream to the browser in real-time.
@@ -115,10 +116,11 @@ You can also point Agent Flow at a JSONL event log file:
 ```bash
 pnpm i              # install dependencies for all packages
 pnpm run setup      # configure Claude Code hooks (one-time)
-pnpm run dev        # start dev server + event relay
+pnpm dev            # start dev server + event relay for this repository
+pnpm dev -- /path/to/workspace  # watch a specific workspace instead
 ```
 
-`pnpm run dev` starts both the Next.js dev server and an event relay that receives Claude Code events and streams them to the browser via SSE.
+`pnpm dev` starts both the Next.js dev server and an event relay that receives Claude Code events and streams them to the browser via SSE. With no argument, it watches this repository. To watch another directory, run `pnpm dev -- <directory>`; relative paths are resolved from the directory where you run the command, and absolute paths are also accepted. The command exits before starting either service if the path is missing, is a file, or if more than one path is supplied.
 
 Other scripts:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.js",
-    "dev": "NEXT_PUBLIC_DEMO=0 NEXT_PUBLIC_RELAY_PORT=3001 concurrently -n relay,web -c blue,green \"pnpm run dev:relay\" \"pnpm run dev:web\"",
+    "dev": "node --import tsx scripts/dev.ts",
     "dev:relay": "node scripts/build-relay.js && node scripts/.dev-relay.js",
     "dev:demo": "NEXT_PUBLIC_DEMO=1 pnpm run dev:web",
     "dev:web": "pnpm --filter agent-flow-web run dev",

--- a/scripts/dev-relay.ts
+++ b/scripts/dev-relay.ts
@@ -5,10 +5,11 @@
  */
 import * as http from 'http'
 import { createRelay } from './relay'
+import { resolveRelayWorkspace } from './relay-workspace'
 import { DEFAULT_RELAY_PORT, DEV_WEB_ORIGIN_PATTERN } from '../extension/src/constants'
 
 async function main() {
-  const workspace = process.argv[2] || process.cwd()
+  const workspace = resolveRelayWorkspace(process.argv.slice(2))
 
   console.log('Starting Agent Flow dev relay...\n')
   console.log(`Workspace: ${workspace}`)

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import * as fs from 'fs'
+import * as path from 'path'
+import { spawn } from 'child_process'
+
+export function resolveDevWorkspace(args: string[], cwd = process.cwd()): string {
+  const targetArgs = args[0] === '--' ? args.slice(1) : args
+
+  if (targetArgs.length > 1) {
+    throw new Error('Expected zero or one directory argument.')
+  }
+
+  const workspace = path.resolve(cwd, targetArgs[0] ?? '.')
+  let stat: fs.Stats
+  try {
+    stat = fs.statSync(workspace)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Target directory does not exist: ${workspace}`)
+    }
+    throw error
+  }
+
+  if (!stat.isDirectory()) {
+    throw new Error(`Target path is not a directory: ${workspace}`)
+  }
+
+  return workspace
+}
+
+export function createDevCommands(workspace: string) {
+  return {
+    relay: 'pnpm run dev:relay',
+    web: 'pnpm run dev:web',
+    env: { AGENT_FLOW_WORKSPACE: workspace },
+  }
+}
+
+export function launchDev(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  spawnProcess: typeof spawn = spawn,
+) {
+  const target = args[0] === '--' ? args[1] : args[0]
+  const invocationCwd = target && !path.isAbsolute(target)
+    ? env.INIT_CWD || process.cwd()
+    : process.cwd()
+  const workspace = resolveDevWorkspace(args, invocationCwd)
+  const commands = createDevCommands(workspace)
+  const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+  return spawnProcess(pnpm, [
+    'exec', 'concurrently',
+    '-n', 'relay,web',
+    '-c', 'blue,green',
+    commands.relay,
+    commands.web,
+  ], {
+    env: {
+      ...env,
+      ...commands.env,
+      NEXT_PUBLIC_DEMO: '0',
+      NEXT_PUBLIC_RELAY_PORT: '3001',
+    },
+    stdio: 'inherit',
+  })
+}
+
+function main() {
+  const runner = launchDev(process.argv.slice(2))
+
+  runner.on('error', (error) => {
+    console.error('Failed to start development services:', error.message)
+    process.exit(1)
+  })
+  runner.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal)
+    else process.exit(code ?? 1)
+  })
+}
+
+if (require.main === module) {
+  try {
+    main()
+  } catch (error) {
+    console.error((error as Error).message)
+    process.exit(1)
+  }
+}

--- a/scripts/relay-workspace.ts
+++ b/scripts/relay-workspace.ts
@@ -1,0 +1,8 @@
+export function resolveRelayWorkspace(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  cwd = process.cwd(),
+): string {
+  const targetArgs = args[0] === '--' ? args.slice(1) : args
+  return targetArgs[0] ?? env.AGENT_FLOW_WORKSPACE ?? cwd
+}


### PR DESCRIPTION
## What does this PR do?

`pnpm dev -- <directory>` now lets Agent Flow observe sessions from a chosen directory.

Until now, development always observed the current repository directory. That made it difficult to validate a fix against a session running in another workspace. The command now validates the target directory, forwards it safely to the relay, and keeps bare `pnpm dev` targeting the repository root.

## How to test

1. Run `pnpm dev -- /path/to/other/workspace`.
2. Confirm the relay reports that directory as its workspace.
3. Run `pnpm dev` and confirm it still targets this repository.
4. Run `pnpm test`.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)