### PR TITLE
fix: session switch and replay races in the frontend

### DIFF
--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -94,7 +94,15 @@ export function AgentVisualizer() {
   const sessionCacheRef = useRef<Map<string, { snapshot: ReturnType<typeof saveSnapshot>; eventCount: number }>>(new Map())
   const prevSelectedRef = useRef<string | null>(null)
   useLayoutEffect(() => {
+    if (bridge.selectedSessionId === null && prevSelectedRef.current !== null) {
+      // Bridge reset (panel reopened / relay restarted): cached snapshots are stale
+      sessionCacheRef.current.clear()
+      prevSelectedRef.current = null
+      return
+    }
     if (bridge.selectedSessionId && bridge.selectedSessionId !== prevSelectedRef.current) {
+      // Review/scrub state is per-component, not per-session: the incoming tab is restored live
+      setIsReviewing(false)
       // Save outgoing session state (if any)
       if (prevSelectedRef.current !== null) {
         sessionCacheRef.current.set(prevSelectedRef.current, {

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -225,6 +225,17 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     // Process captured external events (snapshotted outside the main
     // processing to avoid React strict mode double-invocation issues)
     if (capturedEvents) {
+      // Live events are appended at the tail and eventIndex snapped to the end
+      // below; if part of the log had not been replayed yet (review playback,
+      // restored snapshot) those events would be skipped forever. Apply them first.
+      if (!useMockData) {
+        while (newEventIndex < currentState.eventLog.length) {
+          const evt = currentState.eventLog[newEventIndex]
+          currentState = { ...processEventWithContext(evt, { ...currentState, currentTime: evt.time }), currentTime: evt.time }
+          newEventIndex++
+        }
+        newTime = Math.max(newTime, currentState.currentTime)
+      }
       for (const event of capturedEvents) {
         const activeFilter = sessionFilterRef.current
         if (activeFilter && event.sessionId && event.sessionId !== activeFilter) {
@@ -404,9 +415,22 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
 
   const restoreSnapshot = useCallback((snapshot: { simState: SimulationState; blockId: number }) => {
     blockIdCounter.current = snapshot.blockId
-    commitState({ ...snapshot.simState, isPlaying: true })
-    setTimeout(() => syncForceSimulation(snapshot.simState.agents, snapshot.simState.edges), 0)
-  }, [syncForceSimulation, commitState])
+    let st = snapshot.simState
+    // A snapshot taken while paused/scrubbed still has un-replayed log entries.
+    // Restoring it with isPlaying=true would play them back at 1x under a LIVE
+    // badge; fast-forward to the end of the log so the tab comes back live.
+    if (!useMockData && st.eventIndex < st.eventLog.length) {
+      skipForceSyncRef.current = true
+      for (const evt of st.eventLog.slice(st.eventIndex)) {
+        st = { ...processEventWithContext(evt, { ...st, currentTime: evt.time }), currentTime: evt.time }
+      }
+      skipForceSyncRef.current = false
+      const t = Math.max(st.currentTime, st.maxTimeReached)
+      st = { ...snapVisualState(st, t), currentTime: t, eventIndex: st.eventLog.length }
+    }
+    commitState({ ...st, isPlaying: true })
+    setTimeout(() => syncForceSimulation(st.agents, st.edges), 0)
+  }, [syncForceSimulation, commitState, useMockData, processEventWithContext])
 
   return {
     // Canvas reads frameRef directly for 60fps rendering

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -124,6 +124,13 @@ export function useVSCodeBridge(): BridgeHookResult {
         const buf = sessionEventsRef.current.get(event.sessionId) || []
         buf.push(simEvent)
         sessionEventsRef.current.set(event.sessionId, buf)
+        // Keep lastActivityTime roughly current (throttled: one state update per 5s per session)
+        const now = Date.now()
+        setSessions(prev => {
+          const s = prev.find(x => x.id === event.sessionId)
+          if (!s || now - s.lastActivityTime < 5000) return prev
+          return prev.map(x => x.id === event.sessionId ? { ...x, lastActivityTime: now } : x)
+        })
       }
 
       // Deliver to pending if session matches (ref is always current).
@@ -202,6 +209,11 @@ export function useVSCodeBridge(): BridgeHookResult {
         }
       } else if (type === 'started') {
         const session = data as SessionInfo
+        // Resume after inactivity re-sends 'started' for a session we may already
+        // be showing. Re-arming the switch for the same id would set
+        // sessionSwitchPendingRef without anything ever clearing it (the layout
+        // effect only runs when the selection changes), freezing event delivery.
+        const alreadySelected = session.id === selectedSessionIdRef.current
         setSessions(prev => {
           const existing = prev.find(s => s.id === session.id)
           if (existing) {
@@ -212,6 +224,7 @@ export function useVSCodeBridge(): BridgeHookResult {
           }
           return [...prev, session]
         })
+        if (alreadySelected) return
         // Auto-select newly started session.
         // Set switch-pending flag to prevent the animation frame from processing
         // events in the wrong simulation state before useLayoutEffect swaps it.


### PR DESCRIPTION
Three pre-existing frontend races that show up as a tab 'replaying' history under a LIVE badge, or a canvas that stops updating until you switch tabs.

- `session-started` re-sent for the already-selected session (resume after inactivity) armed `sessionSwitchPendingRef` with nothing to clear it, so no event reached the canvas until the user switched tabs and back. A same-id `started` now only updates the session list.
- Live events arriving while part of the eventLog was still un-replayed (review playback, restored snapshot) snapped `eventIndex` to the end and skipped those events forever. They are applied first now.
- `restoreSnapshot` forced `isPlaying` on a paused/scrubbed snapshot, which played the remaining log at 1x while the (component-global) LIVE badge showed. It now fast-forwards to the end of the log, and a tab switch leaves review mode.
- Cached snapshots are dropped on a bridge reset; `lastActivityTime` is refreshed (throttled) from incoming events.

Typecheck clean (`web/node_modules/.bin/tsc --noEmit`). Found during an audit of a backfill feature (#77) but independent of it.

https://claude.ai/code/session_01AGs5TZo6yxv7NHARHawyJf