### PR TITLE
feat: auto-fit toggle, Flatland shapes, model colors

### DIFF
--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -32,6 +32,7 @@ interface CanvasProps {
   showHexGrid: boolean
   zoomToFitTrigger?: number
   pauseAutoFit?: boolean
+  autoFit: boolean
   onAgentClick: (agentId: string | null) => void
   onAgentHover: (agentId: string | null) => void
   onAgentDrag: (agentId: string, x: number, y: number) => void
@@ -45,7 +46,7 @@ interface CanvasProps {
 
 export function AgentCanvas({
   simulationRef,
-  selectedAgentId, hoveredAgentId, showStats, showHexGrid, zoomToFitTrigger, pauseAutoFit,
+  selectedAgentId, hoveredAgentId, showStats, showHexGrid, zoomToFitTrigger, pauseAutoFit, autoFit,
   onAgentClick, onAgentHover, onAgentDrag, onContextMenu, onToolCallClick, selectedToolCallId, onDiscoveryClick, selectedDiscoveryId, showCostOverlay,
 }: CanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -108,7 +109,7 @@ export function AgentCanvas({
     screenToCanvas, doZoomToFit, updateCamera,
   } = useCanvasCamera({
     mainCanvasRef, drawPropsRef, simTimeRef, dimensions,
-    agentCount: sim.agents.size, zoomToFitTrigger, selectedAgentId,
+    agentCount: sim.agents.size, zoomToFitTrigger, selectedAgentId, autoFit,
   })
 
   // ─── Interaction ────────────────────────────────────────────────────────

--- a/web/components/agent-visualizer/canvas/draw-agents.ts
+++ b/web/components/agent-visualizer/canvas/draw-agents.ts
@@ -3,7 +3,7 @@ import { COLORS, getStateColor, contextSegments } from '@/lib/colors'
 import {
   AGENT_DRAW, CONTEXT_BAR, CONTEXT_RING, STATS_OVERLAY,
 } from '@/lib/canvas-constants'
-import { alphaHex, formatTokens } from '@/lib/utils'
+import { alphaHex, formatTokens, getModelColor } from '@/lib/utils'
 import { truncateText, drawHexagon, CLAUDE_SPARK_D, OPENAI_LOGO_D, OPENAI_LOGO_VIEWBOX, drawPolygon, agentSides } from './draw-misc'
 import { getAgentGlowSprite } from './render-cache'
 
@@ -342,7 +342,10 @@ export function drawAgents(
 ) {
   for (const [id, agent] of agents) {
     const radius = agent.isMain ? NODE.radiusMain : NODE.radiusSub
-    const color = getStateColor(agent.state)
+    // Model family colors the node; alert states (error, paused, waiting) keep their state color
+    const modelColor = getModelColor(agent.model)
+    const alert = agent.state === 'error' || agent.state === 'paused' || agent.state === 'waiting_permission'
+    const color = modelColor && !alert ? modelColor : getStateColor(agent.state)
     const isHovered = id === hoveredAgentId
     const isSelected = id === selectedAgentId
 

--- a/web/components/agent-visualizer/canvas/draw-agents.ts
+++ b/web/components/agent-visualizer/canvas/draw-agents.ts
@@ -4,7 +4,7 @@ import {
   AGENT_DRAW, CONTEXT_BAR, CONTEXT_RING, STATS_OVERLAY,
 } from '@/lib/canvas-constants'
 import { alphaHex, formatTokens } from '@/lib/utils'
-import { truncateText, drawHexagon, CLAUDE_SPARK_D, OPENAI_LOGO_D, OPENAI_LOGO_VIEWBOX } from './draw-misc'
+import { truncateText, drawHexagon, CLAUDE_SPARK_D, OPENAI_LOGO_D, OPENAI_LOGO_VIEWBOX, drawPolygon, agentSides } from './draw-misc'
 import { getAgentGlowSprite } from './render-cache'
 
 let _claudeSparkPath: Path2D | null = null
@@ -179,7 +179,7 @@ function drawDepthShadow(ctx: CanvasRenderingContext2D, agent: Agent, r: number)
   ctx.shadowBlur = AGENT_DRAW.shadowBlur
   ctx.shadowOffsetX = AGENT_DRAW.shadowOffsetX
   ctx.shadowOffsetY = AGENT_DRAW.shadowOffsetY
-  drawHexagon(ctx, agent.x, agent.y, r * 0.9)
+  drawPolygon(ctx, agent.x, agent.y, r * 0.9, agentSides(agent))
   ctx.fillStyle = COLORS.cardBgFaintOverlay
   ctx.fill()
   ctx.restore()
@@ -193,13 +193,13 @@ function drawAgentGlow(ctx: CanvasRenderingContext2D, agent: Agent, r: number, c
   ctx.drawImage(sprite, agent.x - Math.ceil(glowR), agent.y - Math.ceil(glowR))
 
   // Ambient outer hex ring
-  drawHexagon(ctx, agent.x, agent.y, r + AGENT_DRAW.outerRingOffset)
+  drawPolygon(ctx, agent.x, agent.y, r + AGENT_DRAW.outerRingOffset, agentSides(agent))
   ctx.strokeStyle = color + '25'
   ctx.lineWidth = 1
   ctx.stroke()
 
   // Inner hex fill
-  drawHexagon(ctx, agent.x, agent.y, r)
+  drawPolygon(ctx, agent.x, agent.y, r, agentSides(agent))
   ctx.fillStyle = COLORS.nodeInterior
   ctx.fill()
 }
@@ -208,7 +208,7 @@ function drawScanline(ctx: CanvasRenderingContext2D, agent: Agent, r: number, co
   const scanSpeed = agent.state === 'thinking' || isHovered || isWaiting ? ANIM.scanline.thinking : ANIM.scanline.normal
   const scanY = agent.y - r + ((time * scanSpeed) % (r * 2))
   ctx.save()
-  drawHexagon(ctx, agent.x, agent.y, r)
+  drawPolygon(ctx, agent.x, agent.y, r, agentSides(agent))
   ctx.clip()
   const scanGrad = ctx.createLinearGradient(agent.x, scanY - AGENT_DRAW.scanlineHalfH, agent.x, scanY + AGENT_DRAW.scanlineHalfH)
   const scanAlpha = isHovered ? '35' : '20'
@@ -221,7 +221,7 @@ function drawScanline(ctx: CanvasRenderingContext2D, agent: Agent, r: number, co
 }
 
 function drawStateRing(ctx: CanvasRenderingContext2D, agent: Agent, r: number, color: string, isHovered: boolean, isSelected: boolean, isWaiting: boolean, time: number) {
-  drawHexagon(ctx, agent.x, agent.y, r)
+  drawPolygon(ctx, agent.x, agent.y, r, agentSides(agent))
   ctx.strokeStyle = color
   ctx.lineWidth = (isSelected || isHovered) ? 2.5 : 2
   if (agent.state === 'complete') {

--- a/web/components/agent-visualizer/canvas/draw-misc.ts
+++ b/web/components/agent-visualizer/canvas/draw-misc.ts
@@ -53,9 +53,18 @@ export function drawTetherLine(ctx: CanvasRenderingContext2D, agent: Agent, tran
 
 /** Draw a regular hexagon centered at (x, y) */
 export function drawHexagon(ctx: CanvasRenderingContext2D, x: number, y: number, radius: number) {
+  drawPolygon(ctx, x, y, radius, 6)
+}
+
+/** Flatland rule: the orchestrator is a hexagon, each nesting level loses one side, down to a triangle. */
+export function agentSides(agent: { depth?: number }): number {
+  return Math.max(3, 6 - (agent.depth ?? 0))
+}
+
+export function drawPolygon(ctx: CanvasRenderingContext2D, x: number, y: number, radius: number, sides: number) {
   ctx.beginPath()
-  for (let i = 0; i < 6; i++) {
-    const angle = (Math.PI / 3) * i - Math.PI / 2
+  for (let i = 0; i < sides; i++) {
+    const angle = (2 * Math.PI / sides) * i - Math.PI / 2
     const px = x + radius * Math.cos(angle)
     const py = y + radius * Math.sin(angle)
     if (i === 0) ctx.moveTo(px, py)

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -23,6 +23,7 @@ import { COLORS } from "@/lib/colors"
 import { MOCK_DURATION } from "@/lib/mock-scenario"
 import { MessageFeedPanel } from "./message-feed-panel"
 import { TopBar } from "./top-bar"
+import { AUTOFIT_PREF_KEY } from "@/lib/canvas-constants"
 import { useAudioEffects } from "@/hooks/use-audio-effects"
 
 export function AgentVisualizer() {
@@ -77,6 +78,16 @@ export function AgentVisualizer() {
     setShowCostOverlay(prev => panel === 'cost' ? !prev : false)
   }, [])
   const [zoomToFitTrigger, setZoomToFitTrigger] = useState(0)
+  // Off by default: with many agents a camera that keeps re-fitting fights the user.
+  const [autoFit, setAutoFit] = useState(() => {
+    try { return localStorage.getItem(AUTOFIT_PREF_KEY) === 'on' } catch { return false }
+  })
+  const toggleAutoFit = useCallback(() => {
+    setAutoFit(prev => {
+      try { localStorage.setItem(AUTOFIT_PREF_KEY, prev ? 'off' : 'on') } catch { /* ignore */ }
+      return !prev
+    })
+  }, [])
 
   const [isReviewing, setIsReviewing] = useState(false)
   const { isMuted, seekingRef, handleToggleMute } = useAudioEffects(agents, toolCalls, isReviewing)
@@ -232,6 +243,7 @@ export function AgentVisualizer() {
       { label: '📊  Toggle Stats', onClick: () => setShowStats(prev => !prev) },
     ] : [
       { label: '🔍  Zoom to Fit', onClick: () => setZoomToFitTrigger(n => n + 1) },
+      { label: `${autoFit ? '☑' : '☐'}  Auto-fit`, onClick: toggleAutoFit },
       { label: '📊  Toggle Stats', onClick: () => setShowStats(prev => !prev) },
       { label: '⬡  Toggle Grid', onClick: () => setShowHexGrid(prev => !prev) },
       { label: '', onClick: () => {}, separator: true },
@@ -278,6 +290,7 @@ export function AgentVisualizer() {
         showHexGrid={showHexGrid}
         zoomToFitTrigger={zoomToFitTrigger}
         pauseAutoFit={selection.contextMenu !== null}
+        autoFit={autoFit}
         onAgentClick={selection.handleAgentClick}
         onAgentHover={selection.setHoveredAgentId}
         onAgentDrag={updateAgentPosition}
@@ -417,6 +430,8 @@ export function AgentVisualizer() {
         isMuted={isMuted}
         onTogglePanel={toggleExclusivePanel}
         onToggleTimeline={() => setShowTimeline(prev => !prev)}
+        autoFit={autoFit}
+        onToggleAutoFit={toggleAutoFit}
         onToggleMute={handleToggleMute}
       />
     </div>

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -98,6 +98,8 @@ export interface TopBarProps {
   onTogglePanel: (panel: 'files' | 'transcript' | 'cost') => void
   onToggleTimeline: () => void
   onToggleMute: () => void
+  autoFit: boolean
+  onToggleAutoFit: () => void
 }
 
 export const TopBar = memo(function TopBar({
@@ -107,6 +109,7 @@ export const TopBar = memo(function TopBar({
   agentCount, totalTokens,
   showFileAttention, showTranscript, showCostOverlay, showTimeline, isMuted,
   onTogglePanel, onToggleTimeline, onToggleMute,
+  autoFit, onToggleAutoFit,
 }: TopBarProps) {
   return (
     <div className="absolute top-3 left-3 right-3 flex items-center gap-4 font-mono text-[10px]" style={{ zIndex: Z.info }}>
@@ -156,6 +159,7 @@ export const TopBar = memo(function TopBar({
 
         {/* Independent toggles */}
         <ToggleButton active={showTimeline} onClick={onToggleTimeline}>Timeline</ToggleButton>
+        <ToggleButton active={autoFit} onClick={onToggleAutoFit} style={{ border: `1px solid ${COLORS.toggleBorder}` }}>Auto-fit</ToggleButton>
         <ToggleButton active={!isMuted} onClick={onToggleMute} style={{ border: `1px solid ${COLORS.toggleBorder}` }}>
           {isMuted ? <MutedIcon /> : <UnmutedIcon />}
         </ToggleButton>

--- a/web/hooks/simulation/handle-agent-events.ts
+++ b/web/hooks/simulation/handle-agent-events.ts
@@ -81,6 +81,7 @@ export function handleAgentSpawn(
     toolCalls: 0, timeAlive: 0,
     x, y, vx: 0, vy: 0,
     pinned: false, isMain,
+    depth: parentId ? (state.agents.get(parentId)?.depth ?? 0) + 1 : 0,
     ...(runtime ? { runtime } : {}),
     ...(model ? { model } : {}),
     task,

--- a/web/hooks/use-canvas-camera.ts
+++ b/web/hooks/use-canvas-camera.ts
@@ -27,6 +27,8 @@ interface CameraOptions {
   agentCount: number
   zoomToFitTrigger?: number
   selectedAgentId: string | null
+  /** Keep the camera continuously fitted to the graph. When false, fit only happens on request. */
+  autoFit: boolean
 }
 
 export function useCanvasCamera({
@@ -37,6 +39,7 @@ export function useCanvasCamera({
   agentCount,
   zoomToFitTrigger,
   selectedAgentId,
+  autoFit,
 }: CameraOptions) {
   const transformRef = useRef<Transform>({ x: 0, y: 0, scale: 1 })
   const userHasNavigatedRef = useRef(false)
@@ -159,20 +162,22 @@ export function useCanvasCamera({
   }, [getDescendantIds, drawPropsRef, simTimeRef])
 
   const doZoomToFit = useCallback(() => {
-    userHasNavigatedRef.current = false
+    // One-shot fit; only re-engage continuous fitting when auto-fit is on
+    if (autoFit) userHasNavigatedRef.current = false
     const target = computeFitTransform()
     if (target) targetTransformRef.current = target
-  }, [computeFitTransform])
+  }, [computeFitTransform, autoFit])
 
   useEffect(() => {
     if (zoomToFitTrigger && zoomToFitTrigger > 0) doZoomToFit()
   }, [zoomToFitTrigger, doZoomToFit])
 
-  // Re-engage auto-fit when selection changes
+  // Re-engage auto-fit when selection changes (only in auto-fit mode)
   useEffect(() => {
+    if (!autoFit) return
     userHasNavigatedRef.current = false
     targetTransformRef.current = null
-  }, [selectedAgentId])
+  }, [selectedAgentId, autoFit])
 
   const screenToCanvas = useCallback((screenX: number, screenY: number) => {
     const canvas = mainCanvasRef.current
@@ -201,7 +206,7 @@ export function useCanvasCamera({
     }
 
     // Auto-fit
-    if (!userHasNavigatedRef.current && !isDragging && !pauseAutoFit) {
+    if (autoFit && !userHasNavigatedRef.current && !isDragging && !pauseAutoFit) {
       const fit = computeFitTransform()
       if (fit) targetTransformRef.current = fit
     }
@@ -221,7 +226,7 @@ export function useCanvasCamera({
         transformRef.current = { x: nx, y: ny, scale: ns }
       }
     }
-  }, [computeFitTransform])
+  }, [computeFitTransform, autoFit])
 
   return {
     transformRef,

--- a/web/lib/agent-types.ts
+++ b/web/lib/agent-types.ts
@@ -28,6 +28,9 @@ export interface Agent {
   vy: number
   pinned: boolean
   isMain: boolean
+  /** Nesting level: 0 for the orchestrator, parent.depth + 1 for subagents.
+   *  Drives the Flatland shape rule (fewer sides the deeper you go). */
+  depth?: number
   /** Which agent runtime produced this agent — used to pick the brand logo.
    *  Optional for forward compat with events that don't carry it (defaults to 'claude'). */
   runtime?: 'claude' | 'codex'

--- a/web/lib/canvas-constants.ts
+++ b/web/lib/canvas-constants.ts
@@ -4,12 +4,12 @@
  *  (formatModelName in utils.ts), context-window sizes, and cost rates all
  *  derive from this table — add new families here and nowhere else.
  *  Rates are blended $/M-token (0.75 × input + 0.25 × output per-MTok). */
-export const CLAUDE_FAMILIES: ReadonlyArray<{ name: string; context: number; rate: number }> = [
-  { name: 'fable',  context: 1_000_000, rate: 20 }, // $10 in / $50 out
-  { name: 'mythos', context: 1_000_000, rate: 20 }, // $10 in / $50 out
-  { name: 'opus',   context: 1_000_000, rate: 10 }, // $5 in / $25 out
-  { name: 'sonnet', context: 1_000_000, rate: 6 },  // $3 in / $15 out
-  { name: 'haiku',  context: 200_000,   rate: 2 },  // $1 in / $5 out
+export const CLAUDE_FAMILIES: ReadonlyArray<{ name: string; context: number; rate: number; color: string }> = [
+  { name: 'fable',  context: 1_000_000, rate: 20, color: '#66ccff' }, // $10 in / $50 out — azure
+  { name: 'mythos', context: 1_000_000, rate: 20, color: '#66ccff' }, // $10 in / $50 out
+  { name: 'opus',   context: 1_000_000, rate: 10, color: '#ff8c42' }, // $5 in / $25 out — orange
+  { name: 'sonnet', context: 1_000_000, rate: 6,  color: '#f0f4f8' }, // $3 in / $15 out — white
+  { name: 'haiku',  context: 200_000,   rate: 2,  color: '#66ffaa' }, // $1 in / $5 out — green
 ]
 
 /** Regex alternation fragment of all Claude family names (e.g. 'fable|mythos|…'). */

--- a/web/lib/canvas-constants.ts
+++ b/web/lib/canvas-constants.ts
@@ -122,6 +122,9 @@ export const AUTO_SCROLL_THRESHOLD = 60
 
 // ─── Camera / interaction constants ─────────────────────────────────────────
 
+/** localStorage key for the auto-fit camera preference */
+export const AUTOFIT_PREF_KEY = 'agent-flow-autofit'
+
 export const CAMERA = {
   zoomStepDown: 0.92,
   zoomStepUp: 1.08,

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -1,4 +1,4 @@
-import { CLAUDE_FAMILY_ALTERNATION } from './canvas-constants'
+import { CLAUDE_FAMILIES, CLAUDE_FAMILY_ALTERNATION } from './canvas-constants'
 
 /** Convert a 0–1 alpha value to a two-character hex string (e.g. 0.5 → '80') */
 export function alphaHex(alpha: number): string {
@@ -45,4 +45,12 @@ export function formatModelName(model: string): string {
   if (gpt) return `GPT-${gpt[1]}`
 
   return base
+}
+
+/** Node color for a model family (null for unknown/absent models — caller falls back to the state color). */
+export function getModelColor(model?: string): string | null {
+  if (!model) return null
+  const m = model.toLowerCase()
+  const fam = CLAUDE_FAMILIES.find(f => m.includes(f.name))
+  return fam ? fam.color : null
 }


### PR DESCRIPTION
Three small canvas changes aimed at sessions with many agents.

- **Auto-fit toggle.** Continuous auto-fit re-engaged on every selection change and after every manual fit, fighting the user once the graph is busy. It is now a persistent toggle (top bar + context menu, localStorage), off by default. Shift+F and 'Zoom to Fit' remain one-shot fits; Cmd/Ctrl+wheel zoom and drag pan are unchanged.
- **Flatland shapes.** Orchestrator stays a hexagon; each nesting level loses one side (pentagon, square, triangle). `Agent.depth` is set at spawn from the parent.
- **Model colors.** Fable/Mythos azure, Opus orange, Sonnet white, Haiku green, defined in `CLAUDE_FAMILIES` next to context size and cost. Error, paused and waiting-permission keep their state colors so alerts stay visible.

Happy to split if you only want some of these.

https://claude.ai/code/session_01AGs5TZo6yxv7NHARHawyJf