### PR TITLE
feat: session manager modal

### DIFF
--- a/extension/src/codex-session-watcher.ts
+++ b/extension/src/codex-session-watcher.ts
@@ -52,6 +52,7 @@ interface WatchedCodexSession {
   sessionDetected: boolean
   sessionCompleted: boolean
   label: string
+  cwd?: string
   rolloutState: CodexRolloutState
   parser: CodexRolloutParser
 }
@@ -167,6 +168,7 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
     return Array.from(this.sessions.values()).map(s => ({
       id: s.sessionId,
       label: s.label,
+      cwd: s.cwd,
       status: s.sessionCompleted ? 'completed' : 'active',
       startTime: s.sessionStartTime,
       lastActivityTime: s.lastActivityTime,
@@ -177,7 +179,7 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
     for (const [id, session] of this.sessions) {
       if (!session.sessionDetected) continue
       if (sessionIds && !sessionIds.includes(id)) continue
-      this._onSessionLifecycle.fire({ type: 'started', sessionId: id, label: session.label })
+      this._onSessionLifecycle.fire({ type: 'started', sessionId: id, label: session.label, cwd: session.cwd })
     }
   }
 
@@ -232,9 +234,9 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
         const ageS = (Date.now() - stat.mtimeMs) / 1000
         if (ageS > ACTIVE_SESSION_AGE_S) continue
 
+        const cwd = readSessionCwd(filePath)
         // Workspace filter — only attach if cwd matches (or no workspace set)
         if (this.workspacePath) {
-          const cwd = readSessionCwd(filePath)
           if (cwd === null) continue
           const resolvedCwd = this.resolvePath(cwd)
           if (!resolvedCwd || !this.pathMatchesWorkspace(resolvedCwd)) {
@@ -243,7 +245,7 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
           }
         }
 
-        this.attachSession(filePath, stat)
+        this.attachSession(filePath, stat, cwd ?? undefined)
       }
     }
 
@@ -280,7 +282,7 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
     return candidate.startsWith(workspace + path.sep)
   }
 
-  private attachSession(filePath: string, stat: fs.Stats): void {
+  private attachSession(filePath: string, stat: fs.Stats, cwd?: string): void {
     const sessionId = this.sessionIdFor(filePath)
     const label = `Codex ${sessionId.slice(0, SESSION_ID_DISPLAY)}`
 
@@ -296,7 +298,7 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
         const s = this.sessions.get(sessionId)
         if (!s || !s.label.startsWith('Codex ')) return // only replace auto-label
         s.label = newLabel
-        this._onSessionLifecycle.fire({ type: 'updated', sessionId, label: newLabel })
+        this._onSessionLifecycle.fire({ type: 'updated', sessionId, label: newLabel, cwd: s.cwd })
       },
     })
 
@@ -313,6 +315,7 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
       sessionDetected: false,
       sessionCompleted: false,
       label,
+      cwd,
       rolloutState: createCodexRolloutState(),
       parser,
     }
@@ -323,7 +326,7 @@ export class CodexSessionWatcher implements AgentSessionWatcher {
 
     session.sessionDetected = true
     this._onSessionDetected.fire(sessionId)
-    this._onSessionLifecycle.fire({ type: 'started', sessionId, label })
+    this._onSessionLifecycle.fire({ type: 'started', sessionId, label, cwd })
 
     try {
       session.fileWatcher = fs.watch(filePath, () => this.readNewLines(sessionId))

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -101,7 +101,7 @@ export const RESULT_MAX = 200
 export const MESSAGE_MAX = 2000
 
 /** Session tab label */
-export const SESSION_LABEL_MAX = 14
+export const SESSION_LABEL_MAX = 60
 
 /** Truncated label text (label - ellipsis) */
 export const SESSION_LABEL_TRUNCATED = SESSION_LABEL_MAX - 2

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -31,6 +31,8 @@ export interface AgentEvent {
 export interface SessionInfo {
   id: string
   label: string
+  /** Working directory of the session (used to disambiguate tabs across projects) */
+  cwd?: string
   status: 'active' | 'completed'
   startTime: number
   lastActivityTime: number
@@ -47,7 +49,7 @@ export type ExtensionToWebviewMessage =
   | { type: 'session-list'; sessions: SessionInfo[] }
   | { type: 'session-started'; session: SessionInfo }
   | { type: 'session-ended'; sessionId: string }
-  | { type: 'session-updated'; sessionId: string; label: string }
+  | { type: 'session-updated'; sessionId: string; label: string; cwd?: string }
 
 export interface VisualizerConfig {
   mode: 'live' | 'replay'
@@ -71,6 +73,7 @@ export interface TranscriptEntry {
   sessionId: string
   type: string
   uuid?: string
+  cwd?: string
   message: {
     role: string
     model?: string
@@ -188,6 +191,7 @@ export interface WatchedSession {
   subagentsDir: string | null
   label: string
   labelSet: boolean
+  cwd?: string
   model: string | null
   /** Maps agent names to their last emitted model ID — re-emits on model change */
   modelDetectedAgents: Map<string, string>

--- a/extension/src/session-runtime.ts
+++ b/extension/src/session-runtime.ts
@@ -21,6 +21,7 @@ export interface SessionLifecycleEvent {
   type: 'started' | 'ended' | 'updated'
   sessionId: string
   label: string
+  cwd?: string
 }
 
 /** Interface every runtime's watcher implements. Uses portable typed-event
@@ -100,13 +101,14 @@ export function wireWatcherToPanel(
         session: {
           id: lifecycle.sessionId,
           label: lifecycle.label,
+          cwd: lifecycle.cwd,
           status: 'active',
           startTime: Date.now(),
           lastActivityTime: Date.now(),
         },
       })
     } else if (lifecycle.type === 'updated') {
-      panel.postMessage({ type: 'session-updated', sessionId: lifecycle.sessionId, label: lifecycle.label })
+      panel.postMessage({ type: 'session-updated', sessionId: lifecycle.sessionId, label: lifecycle.label, cwd: lifecycle.cwd })
     } else {
       panel.postMessage({ type: 'session-ended', sessionId: lifecycle.sessionId })
     }

--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -94,6 +94,7 @@ export class SessionWatcher implements AgentSessionWatcher {
     return Array.from(this.sessions.values()).map(s => ({
       id: s.sessionId,
       label: s.label,
+      cwd: s.cwd,
       status: s.sessionCompleted ? 'completed' : 'active',
       startTime: s.sessionStartTime,
       lastActivityTime: s.lastActivityTime,
@@ -428,7 +429,7 @@ export class SessionWatcher implements AgentSessionWatcher {
 
     // Emit session start
     this._onSessionDetected.fire(sessionId)
-    this._onSessionLifecycle.fire({ type: 'started', sessionId, label: session.label })
+    this._onSessionLifecycle.fire({ type: 'started', sessionId, label: session.label, cwd: session.cwd })
 
     this.emit({
       time: 0,
@@ -520,7 +521,7 @@ export class SessionWatcher implements AgentSessionWatcher {
           ...(session.model ? { model: session.model } : {}),
         },
       }, sessionId)
-      this._onSessionLifecycle.fire({ type: 'started', sessionId, label: session.label })
+      this._onSessionLifecycle.fire({ type: 'started', sessionId, label: session.label, cwd: session.cwd })
     }
 
     if (session.inactivityTimer) {

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -32,7 +32,7 @@ export interface TranscriptParserDelegate {
   emit(event: AgentEvent, sessionId?: string): void
   elapsed(sessionId?: string): number
   getSession(sessionId: string): WatchedSession | undefined
-  fireSessionLifecycle(event: { type: 'started' | 'ended' | 'updated'; sessionId: string; label: string }): void
+  fireSessionLifecycle(event: { type: 'started' | 'ended' | 'updated'; sessionId: string; label: string; cwd?: string }): void
   emitContextUpdate(agentName: string, session: WatchedSession, sessionId?: string): void
 }
 
@@ -130,6 +130,7 @@ export class TranscriptParser {
       sessionId: parsed.sessionId as string,
       type: parsed.type as string,
       uuid: parsed.uuid as string | undefined,
+      cwd: typeof parsed.cwd === 'string' ? parsed.cwd : undefined,
       message: msg,
     }
 
@@ -561,6 +562,7 @@ export class TranscriptParser {
   extractSessionLabel(entries: TranscriptEntry[], session: WatchedSession): void {
     if (session.labelSet) return
     for (const entry of entries) {
+      if (!session.cwd && entry.cwd) session.cwd = entry.cwd
       if (entry.type !== 'user') continue
       const text = this.extractUserMessageText(entry)
       if (text) {
@@ -606,12 +608,14 @@ export class TranscriptParser {
   /** Update session label on first user message and notify the webview */
   maybeSetSessionLabel(entry: TranscriptEntry, sessionId: string): void {
     const session = this.delegate.getSession(sessionId)
-    if (!session || session.labelSet) return
+    if (!session) return
+    if (!session.cwd && entry.cwd) session.cwd = entry.cwd
+    if (session.labelSet) return
     if (entry.type !== 'user') return
     const text = this.extractUserMessageText(entry)
     if (!text) return
     session.label = this.truncateLabel(text)
     session.labelSet = true
-    this.delegate.fireSessionLifecycle({ type: 'updated', sessionId, label: session.label })
+    this.delegate.fireSessionLifecycle({ type: 'updated', sessionId, label: session.label, cwd: session.cwd })
   }
 }

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -100,16 +100,16 @@ function broadcastEvent(event: AgentEvent) {
   broadcast(JSON.stringify({ type: 'agent-event', event }))
 }
 
-function broadcastSessionLifecycle(type: 'started' | 'ended' | 'updated', sessionId: string, label: string) {
+function broadcastSessionLifecycle(type: 'started' | 'ended' | 'updated', sessionId: string, label: string, cwd?: string) {
   if (type === 'started') {
     broadcast(JSON.stringify({
       type: 'session-started',
-      session: { id: sessionId, label, status: 'active', startTime: Date.now(), lastActivityTime: Date.now() } as SessionInfo,
+      session: { id: sessionId, label, cwd, status: 'active', startTime: Date.now(), lastActivityTime: Date.now() } as SessionInfo,
     }))
   } else if (type === 'ended') {
     broadcast(JSON.stringify({ type: 'session-ended', sessionId }))
   } else if (type === 'updated') {
-    broadcast(JSON.stringify({ type: 'session-updated', sessionId, label }))
+    broadcast(JSON.stringify({ type: 'session-updated', sessionId, label, cwd }))
   }
 }
 
@@ -144,7 +144,7 @@ const parser = new TranscriptParser({
   emit: emitEvent,
   elapsed,
   getSession: (sessionId: string) => sessions.get(sessionId),
-  fireSessionLifecycle: (event) => broadcastSessionLifecycle(event.type, event.sessionId, event.label),
+  fireSessionLifecycle: (event) => broadcastSessionLifecycle(event.type, event.sessionId, event.label, event.cwd),
   emitContextUpdate,
 })
 
@@ -171,7 +171,7 @@ function resetInactivityTimer(sessionId: string) {
       payload: { name: ORCHESTRATOR_NAME, isMain: true, task: session.label, ...(session.model ? { model: session.model } : {}) },
       sessionId,
     })
-    broadcastSessionLifecycle('started', sessionId, session.label)
+    broadcastSessionLifecycle('started', sessionId, session.label, session.cwd)
   }
 
   if (session.inactivityTimer) clearTimeout(session.inactivityTimer)
@@ -219,7 +219,7 @@ function watchSession(sessionId: string, filePath: string) {
   session.fileSize = stat.size
   parser.extractSessionLabel(catchUpEntries, session)
 
-  broadcastSessionLifecycle('started', sessionId, session.label)
+  broadcastSessionLifecycle('started', sessionId, session.label, session.cwd)
   broadcastEvent({
     time: 0, type: 'agent_spawn',
     payload: { name: ORCHESTRATOR_NAME, isMain: true, task: session.label, ...(session.model ? { model: session.model } : {}) },
@@ -434,7 +434,7 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
     codexWatcher = new CodexSessionWatcher(workspace)
     codexWatcher.onEvent((event) => broadcastEvent(event))
     codexWatcher.onSessionLifecycle((lifecycle) => {
-      broadcastSessionLifecycle(lifecycle.type, lifecycle.sessionId, lifecycle.label)
+      broadcastSessionLifecycle(lifecycle.type, lifecycle.sessionId, lifecycle.label, lifecycle.cwd)
     })
     codexWatcher.start()
   }
@@ -490,7 +490,7 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
       for (const session of sessions.values()) {
         if (!session.sessionDetected) continue
         sessionList.push({
-          id: session.sessionId, label: session.label,
+          id: session.sessionId, label: session.label, cwd: session.cwd,
           status: session.sessionCompleted ? 'completed' : 'active',
           startTime: session.sessionStartTime, lastActivityTime: session.lastActivityTime,
         })

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -23,6 +23,9 @@ import { COLORS } from "@/lib/colors"
 import { MOCK_DURATION } from "@/lib/mock-scenario"
 import { MessageFeedPanel } from "./message-feed-panel"
 import { TopBar } from "./top-bar"
+import { SessionManagerModal } from './session-manager-modal'
+import { useSessionNames } from '@/hooks/use-session-names'
+import { shouldShowFolder } from '@/lib/session-label'
 import { useAudioEffects } from "@/hooks/use-audio-effects"
 
 export function AgentVisualizer() {
@@ -69,6 +72,9 @@ export function AgentVisualizer() {
   const [showTimeline, setShowTimeline] = useState(false)
   const [showFileAttention, setShowFileAttention] = useState(false)
   const [showTranscript, setShowTranscript] = useState(false)
+  const [showSessionManager, setShowSessionManager] = useState(false)
+  const { names: sessionNames, rename: renameSession } = useSessionNames()
+  const showFolder = shouldShowFolder(bridge.sessions, bridge.isVSCode)
 
   // Mutually exclusive panel toggling — opening one closes the others
   const toggleExclusivePanel = useCallback((panel: 'files' | 'transcript' | 'cost') => {
@@ -406,6 +412,10 @@ export function AgentVisualizer() {
         sessionsWithActivity={bridge.sessionsWithActivity}
         onSelectSession={bridge.selectSession}
         onCloseSession={handleCloseSession}
+        onOpenSessionManager={() => setShowSessionManager(true)}
+        showFolder={showFolder}
+        customNames={sessionNames}
+        onRenameSession={renameSession}
         isVSCode={bridge.isVSCode}
         connectionStatus={bridge.connectionStatus}
         agentCount={agents.size}
@@ -418,6 +428,19 @@ export function AgentVisualizer() {
         onTogglePanel={toggleExclusivePanel}
         onToggleTimeline={() => setShowTimeline(prev => !prev)}
         onToggleMute={handleToggleMute}
+      />
+
+      <SessionManagerModal
+        visible={showSessionManager}
+        sessions={bridge.sessions}
+        selectedSessionId={bridge.selectedSessionId}
+        sessionsWithActivity={bridge.sessionsWithActivity}
+        showFolder={showFolder}
+        customNames={sessionNames}
+        onSelectSession={bridge.selectSession}
+        onCloseSession={handleCloseSession}
+        onRenameSession={renameSession}
+        onClose={() => setShowSessionManager(false)}
       />
     </div>
     </OpenFileProvider>

--- a/web/components/agent-visualizer/session-manager-modal.tsx
+++ b/web/components/agent-visualizer/session-manager-modal.tsx
@@ -39,7 +39,15 @@ export function SessionManagerModal({
 
   useEffect(() => {
     if (!visible) return
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { e.stopPropagation(); onClose() } }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.stopPropagation()
+      // Escape while renaming only cancels the edit; a second Escape closes the modal
+      setEditingId(current => {
+        if (current === null) onClose()
+        return null
+      })
+    }
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)
   }, [visible, onClose])
@@ -93,9 +101,8 @@ export function SessionManagerModal({
                     background: isSelected ? COLORS.tabSelectedBg : 'transparent',
                     border: `1px solid ${isSelected ? COLORS.tabSelectedBorder : 'transparent'}`,
                   }}
-                  onClick={() => { onSelectSession(session.id); onClose() }}
-                  onDoubleClick={(e) => { e.stopPropagation(); setDraft(customNames[session.id] ?? ''); setEditingId(session.id) }}
-                  title="Click to open · double-click to rename"
+                  onClick={() => { if (editingId !== session.id) { onSelectSession(session.id); onClose() } }}
+                  title="Click to open · ✎ to rename"
                 >
                   <span
                     className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"

--- a/web/components/agent-visualizer/session-manager-modal.tsx
+++ b/web/components/agent-visualizer/session-manager-modal.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { COLORS } from '@/lib/colors'
+import { Z } from '@/lib/agent-types'
+import type { SessionInfo } from '@/lib/vscode-bridge'
+import { folderName, sessionDisplayLabel } from '@/lib/session-label'
+import { GlassCard } from './glass-card'
+import { PanelHeader, stopPropagationHandlers } from './shared-ui'
+
+interface SessionManagerModalProps {
+  visible: boolean
+  sessions: SessionInfo[]
+  selectedSessionId: string | null
+  sessionsWithActivity: Set<string>
+  showFolder: boolean
+  customNames: Record<string, string>
+  onSelectSession: (id: string) => void
+  onCloseSession: (id: string) => void
+  onRenameSession: (id: string, name: string) => void
+  onClose: () => void
+}
+
+function ago(ms: number): string {
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000))
+  if (s < 60) return `${s}s ago`
+  if (s < 3600) return `${Math.round(s / 60)}m ago`
+  if (s < 86400) return `${Math.round(s / 3600)}h ago`
+  return `${Math.round(s / 86400)}d ago`
+}
+
+export function SessionManagerModal({
+  visible, sessions, selectedSessionId, sessionsWithActivity, showFolder, customNames,
+  onSelectSession, onCloseSession, onRenameSession, onClose,
+}: SessionManagerModalProps) {
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+  const [filter, setFilter] = useState('')
+
+  useEffect(() => {
+    if (!visible) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { e.stopPropagation(); onClose() } }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [visible, onClose])
+
+  // Active first, then most recent
+  const sorted = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    return [...sessions]
+      .filter(s => !q || sessionDisplayLabel(s, customNames[s.id], true).toLowerCase().includes(q) || (s.cwd ?? '').toLowerCase().includes(q))
+      .sort((a, b) => {
+        const act = (b.status === 'active' ? 1 : 0) - (a.status === 'active' ? 1 : 0)
+        return act || b.lastActivityTime - a.lastActivityTime
+      })
+  }, [sessions, filter, customNames])
+
+  const commit = (id: string) => { onRenameSession(id, draft); setEditingId(null) }
+
+  if (!visible) return null
+
+  return (
+    <div
+      className="absolute inset-0 flex items-center justify-center"
+      style={{ zIndex: Z.contextMenu, background: 'rgba(0,0,0,0.45)' }}
+      onClick={onClose}
+    >
+      <div {...stopPropagationHandlers} onClick={(e) => e.stopPropagation()} style={{ width: 'min(720px, 90vw)' }}>
+        <GlassCard visible={visible} className="p-3 font-mono text-[11px]" style={{ maxHeight: '75vh', display: 'flex', flexDirection: 'column' }}>
+          <PanelHeader onClose={onClose}>
+            <span style={{ color: COLORS.holoBright }}>Sessions</span>
+            <span style={{ color: COLORS.textMuted }}>{sessions.length}</span>
+          </PanelHeader>
+          <input
+            autoFocus
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter by name or path…"
+            className="w-full mb-2 px-2 py-1 rounded bg-transparent outline-none"
+            style={{ border: `1px solid ${COLORS.holoBorder06}`, color: COLORS.holoBright }}
+          />
+          <div className="overflow-y-auto" style={{ minHeight: 0 }}>
+            {sorted.length === 0 && <div style={{ color: COLORS.textMuted }}>No sessions</div>}
+            {sorted.map(session => {
+              const isSelected = session.id === selectedSessionId
+              const live = session.status === 'active' || sessionsWithActivity.has(session.id)
+              const label = sessionDisplayLabel(session, customNames[session.id], showFolder)
+              return (
+                <div
+                  key={session.id}
+                  className="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer"
+                  style={{
+                    background: isSelected ? COLORS.tabSelectedBg : 'transparent',
+                    border: `1px solid ${isSelected ? COLORS.tabSelectedBorder : 'transparent'}`,
+                  }}
+                  onClick={() => { onSelectSession(session.id); onClose() }}
+                  onDoubleClick={(e) => { e.stopPropagation(); setDraft(customNames[session.id] ?? ''); setEditingId(session.id) }}
+                  title="Click to open · double-click to rename"
+                >
+                  <span
+                    className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+                    style={{ background: live ? COLORS.complete : COLORS.idle + '40', boxShadow: live ? `0 0 4px ${COLORS.complete}` : 'none' }}
+                  />
+                  <div className="min-w-0 flex-1">
+                    {editingId === session.id ? (
+                      <input
+                        autoFocus
+                        value={draft}
+                        placeholder={label}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onClick={(e) => e.stopPropagation()}
+                        onBlur={() => commit(session.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') commit(session.id)
+                          else if (e.key === 'Escape') { e.stopPropagation(); setEditingId(null) }
+                        }}
+                        className="w-full bg-transparent outline-none"
+                        style={{ color: COLORS.holoBright }}
+                      />
+                    ) : (
+                      <div className="truncate" style={{ color: isSelected ? COLORS.holoBright : COLORS.textMuted }}>
+                        {label}
+                        {customNames[session.id] && <span style={{ color: COLORS.textMuted, marginLeft: 6 }}>({session.label})</span>}
+                      </div>
+                    )}
+                    <div className="truncate" style={{ color: COLORS.textMuted, opacity: 0.6, fontSize: 9 }}>
+                      {session.cwd ? `${folderName(session.cwd)} · ${session.cwd}` : session.id.slice(0, 8)}
+                    </div>
+                  </div>
+                  <span className="flex-shrink-0" style={{ color: COLORS.textMuted, fontSize: 9 }}>
+                    {session.status === 'active' ? 'active' : 'done'} · {ago(session.lastActivityTime)}
+                  </span>
+                  <button
+                    className="flex-shrink-0 px-1 opacity-50 hover:opacity-100"
+                    style={{ color: COLORS.textMuted }}
+                    title="Rename"
+                    onClick={(e) => { e.stopPropagation(); setDraft(customNames[session.id] ?? ''); setEditingId(session.id) }}
+                  >
+                    ✎
+                  </button>
+                  <button
+                    className="flex-shrink-0 px-1 opacity-50 hover:opacity-100"
+                    style={{ color: COLORS.tabClose }}
+                    title="Dismiss"
+                    onClick={(e) => { e.stopPropagation(); onCloseSession(session.id) }}
+                  >
+                    ✕
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        </GlassCard>
+      </div>
+    </div>
+  )
+}

--- a/web/components/agent-visualizer/session-tabs.tsx
+++ b/web/components/agent-visualizer/session-tabs.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 import { COLORS } from '@/lib/colors'
 import type { SessionInfo } from '@/lib/vscode-bridge'
-import { sessionDisplayLabel } from '@/lib/session-label'
+import { folderName } from '@/lib/session-label'
 
 interface SessionTabsProps {
   sessions: SessionInfo[]
@@ -36,10 +36,14 @@ export function SessionTabs({
     setEditingId(null)
   }, [onRenameSession])
 
+  /** Text part of the tab (folder is rendered as its own chip) */
   const displayLabel = useCallback(
-    (session: SessionInfo) => sessionDisplayLabel(session, customNames[session.id], showFolder),
-    [customNames, showFolder],
+    (session: SessionInfo) => customNames[session.id] || session.label,
+    [customNames],
   )
+
+  // Most recently active first; the selected tab keeps its slot among peers
+  const ordered = [...sessions].sort((a, b) => b.lastActivityTime - a.lastActivityTime)
 
   const setButtonRef = useCallback((id: string, el: HTMLButtonElement | null) => {
     if (el) buttonRefs.current.set(id, el)
@@ -54,13 +58,14 @@ export function SessionTabs({
   }, [selectedSessionId])
 
   return (
-    <div className="flex gap-1">
-      {sessions.map(session => {
+    <div className="flex gap-1.5">
+      {ordered.map(session => {
         const isSelected = session.id === selectedSessionId
         const isActive = session.status === 'active'
         const hasActivity = sessionsWithActivity.has(session.id)
         // Green dot: session is active, OR has unseen background activity
         const showGreen = isActive || hasActivity
+        const folder = showFolder && session.cwd ? folderName(session.cwd) : null
         return (
           <button
             key={session.id}
@@ -71,24 +76,39 @@ export function SessionTabs({
               setDraft(customNames[session.id] ?? '')
               setEditingId(session.id)
             }}
-            title="Right-click to rename"
-            className="group px-1.5 py-0.5 rounded transition-all flex items-center gap-1"
+            title={`${session.cwd ?? ''}\n${session.label}\nRight-click to rename`}
+            className="group px-2.5 py-1 rounded-md transition-all flex items-center gap-2 font-mono text-[11px]"
             style={{
               flexShrink: 0,
+              maxWidth: 260,
               whiteSpace: 'nowrap',
               background: isSelected ? COLORS.tabSelectedBg : COLORS.tabInactiveBg,
               border: `1px solid ${isSelected ? COLORS.tabSelectedBorder : COLORS.tabInactiveBorder}`,
+              boxShadow: isSelected ? `0 0 14px ${COLORS.tabSelectedBg}, inset 0 0 12px ${COLORS.tabInactiveBg}` : 'none',
               color: isSelected ? COLORS.holoBright : COLORS.textMuted,
+              opacity: !isSelected && !isActive ? 0.7 : 1,
             }}
           >
             <span
-              className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+              className="inline-block w-2 h-2 rounded-full flex-shrink-0"
               style={{
                 background: showGreen ? COLORS.complete : COLORS.idle + '40',
-                boxShadow: showGreen ? `0 0 4px ${COLORS.complete}` : 'none',
+                boxShadow: showGreen ? `0 0 6px ${COLORS.complete}` : 'none',
                 animation: hasActivity && !isSelected ? 'pulse 1.5s infinite' : 'none',
               }}
             />
+            {folder && editingId !== session.id && (
+              <span
+                className="flex-shrink-0 px-1 rounded text-[9px] uppercase tracking-wider"
+                style={{
+                  background: isSelected ? COLORS.tabSelectedBorder : COLORS.tabInactiveBorder,
+                  color: isSelected ? COLORS.holoBright : COLORS.textMuted,
+                  maxWidth: 90, overflow: 'hidden', textOverflow: 'ellipsis',
+                }}
+              >
+                {folder}
+              </span>
+            )}
             {editingId === session.id ? (
               <input
                 autoFocus
@@ -101,13 +121,15 @@ export function SessionTabs({
                   if (e.key === 'Enter') commitRename(session.id, draft)
                   else if (e.key === 'Escape') setEditingId(null)
                 }}
-                className="bg-transparent outline-none font-mono text-[10px]"
+                className="bg-transparent outline-none font-mono text-[11px]"
                 style={{ color: COLORS.holoBright, width: Math.max(8, (draft || displayLabel(session)).length) + 'ch' }}
               />
-            ) : displayLabel(session)}
+            ) : (
+              <span className="truncate" style={{ minWidth: 0 }}>{displayLabel(session)}</span>
+            )}
             <span
-              className="ml-0.5 opacity-0 group-hover:opacity-60 transition-opacity cursor-pointer"
-              style={{ color: COLORS.tabClose, fontSize: 8, lineHeight: '10px' }}
+              className="flex-shrink-0 opacity-0 group-hover:opacity-70 transition-opacity cursor-pointer"
+              style={{ color: COLORS.tabClose, fontSize: 10, lineHeight: '12px' }}
               onClick={(e) => {
                 e.stopPropagation()
                 onCloseSession(session.id)

--- a/web/components/agent-visualizer/session-tabs.tsx
+++ b/web/components/agent-visualizer/session-tabs.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 import { COLORS } from '@/lib/colors'
 import type { SessionInfo } from '@/lib/vscode-bridge'
+import { sessionDisplayLabel } from '@/lib/session-label'
 
 interface SessionTabsProps {
   sessions: SessionInfo[]
@@ -12,16 +13,8 @@ interface SessionTabsProps {
   onCloseSession: (id: string) => void
   /** Prefix tab labels with the session's folder name (standalone app, or multiple workspaces) */
   showFolder: boolean
-}
-
-const RENAME_STORAGE_KEY = 'agent-flow-session-names'
-
-function loadCustomNames(): Record<string, string> {
-  try { return JSON.parse(localStorage.getItem(RENAME_STORAGE_KEY) || '{}') } catch { return {} }
-}
-
-function folderName(cwd: string): string {
-  return cwd.replace(/[\\/]+$/, '').split(/[\\/]/).pop() || cwd
+  customNames: Record<string, string>
+  onRenameSession: (id: string, name: string) => void
 }
 
 export function SessionTabs({
@@ -31,28 +24,22 @@ export function SessionTabs({
   onSelectSession,
   onCloseSession,
   showFolder,
+  customNames,
+  onRenameSession,
 }: SessionTabsProps) {
   const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map())
-  const [customNames, setCustomNames] = useState<Record<string, string>>(loadCustomNames)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [draft, setDraft] = useState('')
 
   const commitRename = useCallback((id: string, name: string) => {
-    setCustomNames(prev => {
-      const next = { ...prev }
-      if (name.trim()) next[id] = name.trim()
-      else delete next[id] // empty name = reset to default label
-      try { localStorage.setItem(RENAME_STORAGE_KEY, JSON.stringify(next)) } catch { /* ignore */ }
-      return next
-    })
+    onRenameSession(id, name)
     setEditingId(null)
-  }, [])
+  }, [onRenameSession])
 
-  const displayLabel = useCallback((session: SessionInfo) => {
-    const custom = customNames[session.id]
-    if (custom) return custom
-    return showFolder && session.cwd ? `${folderName(session.cwd)} · ${session.label}` : session.label
-  }, [customNames, showFolder])
+  const displayLabel = useCallback(
+    (session: SessionInfo) => sessionDisplayLabel(session, customNames[session.id], showFolder),
+    [customNames, showFolder],
+  )
 
   const setButtonRef = useCallback((id: string, el: HTMLButtonElement | null) => {
     if (el) buttonRefs.current.set(id, el)

--- a/web/components/agent-visualizer/session-tabs.tsx
+++ b/web/components/agent-visualizer/session-tabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, useState } from 'react'
 import { COLORS } from '@/lib/colors'
 import type { SessionInfo } from '@/lib/vscode-bridge'
 
@@ -10,6 +10,18 @@ interface SessionTabsProps {
   sessionsWithActivity: Set<string>
   onSelectSession: (id: string) => void
   onCloseSession: (id: string) => void
+  /** Prefix tab labels with the session's folder name (standalone app, or multiple workspaces) */
+  showFolder: boolean
+}
+
+const RENAME_STORAGE_KEY = 'agent-flow-session-names'
+
+function loadCustomNames(): Record<string, string> {
+  try { return JSON.parse(localStorage.getItem(RENAME_STORAGE_KEY) || '{}') } catch { return {} }
+}
+
+function folderName(cwd: string): string {
+  return cwd.replace(/[\\/]+$/, '').split(/[\\/]/).pop() || cwd
 }
 
 export function SessionTabs({
@@ -18,8 +30,29 @@ export function SessionTabs({
   sessionsWithActivity,
   onSelectSession,
   onCloseSession,
+  showFolder,
 }: SessionTabsProps) {
   const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map())
+  const [customNames, setCustomNames] = useState<Record<string, string>>(loadCustomNames)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+
+  const commitRename = useCallback((id: string, name: string) => {
+    setCustomNames(prev => {
+      const next = { ...prev }
+      if (name.trim()) next[id] = name.trim()
+      else delete next[id] // empty name = reset to default label
+      try { localStorage.setItem(RENAME_STORAGE_KEY, JSON.stringify(next)) } catch { /* ignore */ }
+      return next
+    })
+    setEditingId(null)
+  }, [])
+
+  const displayLabel = useCallback((session: SessionInfo) => {
+    const custom = customNames[session.id]
+    if (custom) return custom
+    return showFolder && session.cwd ? `${folderName(session.cwd)} · ${session.label}` : session.label
+  }, [customNames, showFolder])
 
   const setButtonRef = useCallback((id: string, el: HTMLButtonElement | null) => {
     if (el) buttonRefs.current.set(id, el)
@@ -46,6 +79,12 @@ export function SessionTabs({
             key={session.id}
             ref={(el) => setButtonRef(session.id, el)}
             onClick={() => onSelectSession(session.id)}
+            onContextMenu={(e) => {
+              e.preventDefault()
+              setDraft(customNames[session.id] ?? '')
+              setEditingId(session.id)
+            }}
+            title="Right-click to rename"
             className="group px-1.5 py-0.5 rounded transition-all flex items-center gap-1"
             style={{
               flexShrink: 0,
@@ -63,7 +102,22 @@ export function SessionTabs({
                 animation: hasActivity && !isSelected ? 'pulse 1.5s infinite' : 'none',
               }}
             />
-            {session.label}
+            {editingId === session.id ? (
+              <input
+                autoFocus
+                value={draft}
+                placeholder={displayLabel(session)}
+                onChange={(e) => setDraft(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+                onBlur={() => commitRename(session.id, draft)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitRename(session.id, draft)
+                  else if (e.key === 'Escape') setEditingId(null)
+                }}
+                className="bg-transparent outline-none font-mono text-[10px]"
+                style={{ color: COLORS.holoBright, width: Math.max(8, (draft || displayLabel(session)).length) + 'ch' }}
+              />
+            ) : displayLabel(session)}
             <span
               className="ml-0.5 opacity-0 group-hover:opacity-60 transition-opacity cursor-pointer"
               style={{ color: COLORS.tabClose, fontSize: 8, lineHeight: '10px' }}

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -83,6 +83,10 @@ export interface TopBarProps {
   sessionsWithActivity: Set<string>
   onSelectSession: (id: string) => void
   onCloseSession: (id: string) => void
+  onOpenSessionManager: () => void
+  showFolder: boolean
+  customNames: Record<string, string>
+  onRenameSession: (id: string, name: string) => void
   // Connection
   isVSCode: boolean
   connectionStatus: ConnectionStatus
@@ -103,6 +107,7 @@ export interface TopBarProps {
 export const TopBar = memo(function TopBar({
   sessions, selectedSessionId, sessionsWithActivity,
   onSelectSession, onCloseSession,
+  onOpenSessionManager, showFolder, customNames, onRenameSession,
   isVSCode, connectionStatus,
   agentCount, totalTokens,
   showFileAttention, showTranscript, showCostOverlay, showTimeline, isMuted,
@@ -110,6 +115,12 @@ export const TopBar = memo(function TopBar({
 }: TopBarProps) {
   return (
     <div className="absolute top-3 left-3 right-3 flex items-center gap-4 font-mono text-[10px]" style={{ zIndex: Z.info }}>
+      {sessions.length > 0 && (
+        <ToggleButton active={false} onClick={onOpenSessionManager} style={{ flexShrink: 0 }}>
+          ☰ {sessions.length}
+        </ToggleButton>
+      )}
+
       {/* Session tabs — scrollable, takes available space */}
       {sessions.length > 1 && (
         <div className="min-w-0 flex-shrink overflow-x-auto scrollbar-hide">
@@ -119,7 +130,9 @@ export const TopBar = memo(function TopBar({
             sessionsWithActivity={sessionsWithActivity}
             onSelectSession={onSelectSession}
             onCloseSession={onCloseSession}
-            showFolder={!isVSCode || new Set(sessions.map(s => s.cwd).filter(Boolean)).size > 1}
+            showFolder={showFolder}
+            customNames={customNames}
+            onRenameSession={onRenameSession}
           />
         </div>
       )}

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -119,6 +119,7 @@ export const TopBar = memo(function TopBar({
             sessionsWithActivity={sessionsWithActivity}
             onSelectSession={onSelectSession}
             onCloseSession={onCloseSession}
+            showFolder={!isVSCode || new Set(sessions.map(s => s.cwd).filter(Boolean)).size > 1}
           />
         </div>
       )}

--- a/web/hooks/use-session-names.ts
+++ b/web/hooks/use-session-names.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+
+const STORAGE_KEY = 'agent-flow-session-names'
+
+function load(): Record<string, string> {
+  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') } catch { return {} }
+}
+
+/** User-assigned session names, persisted per session id in localStorage. */
+export function useSessionNames() {
+  const [names, setNames] = useState<Record<string, string>>(load)
+
+  /** Empty name resets the session to its default label */
+  const rename = useCallback((id: string, name: string) => {
+    setNames(prev => {
+      const next = { ...prev }
+      if (name.trim()) next[id] = name.trim()
+      else delete next[id]
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(next)) } catch { /* ignore */ }
+      return next
+    })
+  }, [])
+
+  return { names, rename }
+}

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -212,7 +212,9 @@ export function useVSCodeBridge(): BridgeHookResult {
           }
           return [...prev, session]
         })
-        // Auto-select newly started session.
+        // Auto-select only when nothing is selected yet: stealing focus every time
+        // another project starts a session is disruptive with many sessions.
+        if (selectedSessionIdRef.current) return
         // Set switch-pending flag to prevent the animation frame from processing
         // events in the wrong simulation state before useLayoutEffect swaps it.
         sessionSwitchPendingRef.current = true

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -220,9 +220,9 @@ export function useVSCodeBridge(): BridgeHookResult {
         selectedSessionIdRef.current = session.id
         setSelectedSessionId(session.id)
       } else if (type === 'updated') {
-        const { sessionId, label } = data as { sessionId: string; label: string }
+        const { sessionId, label, cwd } = data as { sessionId: string; label: string; cwd?: string }
         setSessions(prev => prev.map(s =>
-          s.id === sessionId ? { ...s, label } : s
+          s.id === sessionId ? { ...s, label, cwd: cwd ?? s.cwd } : s
         ))
       } else if (type === 'ended') {
         const sessionId = data as string

--- a/web/lib/bridge-types.ts
+++ b/web/lib/bridge-types.ts
@@ -16,6 +16,7 @@ export interface AgentEvent {
 export interface SessionInfo {
   id: string
   label: string
+  cwd?: string
   status: 'active' | 'completed'
   startTime: number
   lastActivityTime: number

--- a/web/lib/session-label.ts
+++ b/web/lib/session-label.ts
@@ -1,0 +1,17 @@
+import type { SessionInfo } from './bridge-types'
+
+/** Last path segment of a cwd, tolerant of trailing separators and Windows paths */
+export function folderName(cwd: string): string {
+  return cwd.replace(/[\\/]+$/, '').split(/[\\/]/).pop() || cwd
+}
+
+/** Label shown for a session: custom name wins, then optional folder prefix, then the raw label */
+export function sessionDisplayLabel(session: SessionInfo, customName: string | undefined, showFolder: boolean): string {
+  if (customName) return customName
+  return showFolder && session.cwd ? `${folderName(session.cwd)} · ${session.label}` : session.label
+}
+
+/** Whether tabs need a folder prefix: always standalone, in VS Code only when sessions span several cwds */
+export function shouldShowFolder(sessions: SessionInfo[], isVSCode: boolean): boolean {
+  return !isVSCode || new Set(sessions.map(s => s.cwd).filter(Boolean)).size > 1
+}

--- a/web/lib/vscode-bridge.ts
+++ b/web/lib/vscode-bridge.ts
@@ -13,7 +13,7 @@ type InitCallback = () => void
 type EventCallback = (event: AgentEvent) => void
 type StatusCallback = (status: ConnectionStatus, source: string) => void
 type ConfigCallback = (config: Partial<{ mode: string; autoPlay: boolean; showMockData: boolean; disable1MContext: boolean }>) => void
-type SessionCallback = (type: 'list' | 'started' | 'ended' | 'updated' | 'reset', data: SessionInfo[] | SessionInfo | string | { sessionId: string; label: string }) => void
+type SessionCallback = (type: 'list' | 'started' | 'ended' | 'updated' | 'reset', data: SessionInfo[] | SessionInfo | string | { sessionId: string; label: string; cwd?: string }) => void
 
 class VSCodeBridge {
   private _isVSCode = false
@@ -98,7 +98,7 @@ class VSCodeBridge {
 
       case 'session-updated':
         for (const cb of this.sessionListeners) {
-          cb('updated', { sessionId: data.sessionId, label: data.label })
+          cb('updated', { sessionId: data.sessionId, label: data.label, cwd: data.cwd })
         }
         break
     }


### PR DESCRIPTION
Stacked on #76 (folder-prefixed tabs + rename); the diff includes those commits until #76 lands.

Adds a ☰ button in the top bar that opens a modal listing every tracked session: live indicator, display name, folder and full cwd, status and last activity. Click opens the session, ✎ renames it inline (Enter saves, Esc cancels the rename, a second Esc closes the modal), ✕ dismisses it, a filter box narrows by name or path, backdrop click closes.

Custom names live in a shared `useSessionNames` hook (localStorage) and the label helpers in `lib/session-label.ts`, so tabs and modal stay in sync.

https://claude.ai/code/session_01AGs5TZo6yxv7NHARHawyJf