### PR TITLE
feat: export the timeline as a video with sound

### DIFF
--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -3,7 +3,7 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
 import { Agent, Particle, Edge, Discovery, DepthParticle } from '@/lib/agent-types'
 import type { SimulationState } from '@/hooks/simulation/types'
-import { getStateColor } from '@/lib/colors'
+import { getStateColor, COLORS } from '@/lib/colors'
 import { ANIM_SPEED, PERF_OVERLAY, PERF_OVERLAY_ENABLED } from '@/lib/canvas-constants'
 import { BloomRenderer } from './bloom-renderer'
 import { createDepthParticles, updateDepthParticles, drawBackground } from './background-layer'
@@ -41,12 +41,15 @@ interface CanvasProps {
   onDiscoveryClick?: (discoveryId: string | null) => void
   selectedDiscoveryId?: string | null
   showCostOverlay?: boolean
+  /** Full-canvas caption (e.g. '… 3m later …' during an export); drawn into the canvas so captureStream sees it */
+  overlayText?: string | null
 }
 
 export function AgentCanvas({
   simulationRef,
   selectedAgentId, hoveredAgentId, showStats, showHexGrid, zoomToFitTrigger, pauseAutoFit,
   onAgentClick, onAgentHover, onAgentDrag, onContextMenu, onToolCallClick, selectedToolCallId, onDiscoveryClick, selectedDiscoveryId, showCostOverlay,
+  overlayText,
 }: CanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const mainCanvasRef = useRef<HTMLCanvasElement>(null)
@@ -93,7 +96,7 @@ export function AgentCanvas({
     agents: sim.agents, toolCalls: sim.toolCalls,
     particles: sim.particles, edges: sim.edges, discoveries: sim.discoveries,
     selectedAgentId, hoveredAgentId, showStats, showHexGrid,
-    showCostOverlay, selectedToolCallId, selectedDiscoveryId,
+    showCostOverlay, selectedToolCallId, selectedDiscoveryId, overlayText,
     simTime: sim.currentTime, pauseAutoFit, dimensions,
     onAgentDrag, onAgentClick, onAgentHover, onContextMenu,
     onToolCallClick, onDiscoveryClick,
@@ -320,6 +323,22 @@ export function AgentCanvas({
         ctx.restore()
       }
 
+      // Export caption: idle gap card
+      const caption = drawPropsRef.current.overlayText
+      if (caption) {
+        ctx.save()
+        ctx.fillStyle = 'rgba(2, 6, 14, 0.82)'
+        ctx.fillRect(0, 0, w, h)
+        ctx.fillStyle = COLORS.holoBright
+        ctx.font = '500 28px ui-monospace, SFMono-Regular, Menlo, monospace'
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        ctx.shadowColor = COLORS.holoBright
+        ctx.shadowBlur = 18
+        ctx.fillText(caption, w / 2, h / 2)
+        ctx.restore()
+      }
+
     } catch (err) {
       // Log at most once every 5s to avoid flooding the console
       const now = Date.now()
@@ -343,6 +362,7 @@ export function AgentCanvas({
     <div ref={containerRef} className="relative w-full h-full overflow-hidden" style={{ cursor: isDragging ? 'grabbing' : 'grab' }}>
       <canvas
         ref={mainCanvasRef}
+        data-agent-canvas
         style={{ width: dimensions.width, height: dimensions.height }}
         {...handlers}
         className="w-full h-full"

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -23,6 +23,7 @@ import { COLORS } from "@/lib/colors"
 import { MOCK_DURATION } from "@/lib/mock-scenario"
 import { MessageFeedPanel } from "./message-feed-panel"
 import { TopBar } from "./top-bar"
+import { useTimelineExport } from "@/hooks/use-timeline-export"
 import { useAudioEffects } from "@/hooks/use-audio-effects"
 
 export function AgentVisualizer() {
@@ -47,6 +48,7 @@ export function AgentVisualizer() {
     restart,
     setSpeed,
     seekToTime,
+    skipTo,
     updateAgentPosition,
     saveSnapshot,
     restoreSnapshot,
@@ -79,7 +81,9 @@ export function AgentVisualizer() {
   const [zoomToFitTrigger, setZoomToFitTrigger] = useState(0)
 
   const [isReviewing, setIsReviewing] = useState(false)
-  const { isMuted, seekingRef, handleToggleMute } = useAudioEffects(agents, toolCalls, isReviewing)
+  const [isExporting, setIsExporting] = useState(false)
+  const [exportOverlay, setExportOverlay] = useState<string | null>(null)
+  const { isMuted, seekingRef, handleToggleMute, audioRef } = useAudioEffects(agents, toolCalls, isReviewing, isExporting)
 
   // Auto-play on mount
   useEffect(() => {
@@ -180,6 +184,25 @@ export function AgentVisualizer() {
     setIsReviewing(false)
     restart(true)
   }, [restart])
+
+  const timelineExport = useTimelineExport({
+    getCanvas: () => document.querySelector<HTMLCanvasElement>('canvas[data-agent-canvas]'),
+    getAudioStream: () => audioRef.current?.recordingStream() ?? null,
+    getCurrentTime: () => frameRef.current.currentTime,
+    getMaxTime: () => frameRef.current.maxTimeReached,
+    getNextEventTime: () => {
+      const st = frameRef.current
+      return st.eventIndex < st.eventLog.length ? st.eventLog[st.eventIndex].time : null
+    },
+    seekToTime, skipTo, play, pause,
+    setOverlay: setExportOverlay,
+    onDone: handleResumeLive,
+  })
+  useEffect(() => { setIsExporting(timelineExport.isExporting) }, [timelineExport.isExporting])
+  const handleToggleExport = useCallback(() => {
+    if (timelineExport.isExporting) timelineExport.cancelExport()
+    else { setIsReviewing(true); timelineExport.startExport() }
+  }, [timelineExport])
 
   // Keyboard shortcuts
   const keyboardActions = useMemo(() => ({
@@ -287,6 +310,7 @@ export function AgentVisualizer() {
         onDiscoveryClick={selection.handleDiscoveryClick}
         selectedDiscoveryId={selection.selectedDiscoveryId}
         showCostOverlay={showCostOverlay}
+        overlayText={exportOverlay}
       />
 
       {/* Message feed panel (top-left) */}
@@ -418,6 +442,9 @@ export function AgentVisualizer() {
         onTogglePanel={toggleExclusivePanel}
         onToggleTimeline={() => setShowTimeline(prev => !prev)}
         onToggleMute={handleToggleMute}
+        isExporting={timelineExport.isExporting}
+        exportProgress={timelineExport.progress}
+        onToggleExport={handleToggleExport}
       />
     </div>
     </OpenFileProvider>

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -444,6 +444,7 @@ export function AgentVisualizer() {
         onToggleMute={handleToggleMute}
         isExporting={timelineExport.isExporting}
         exportProgress={timelineExport.progress}
+        exportResult={timelineExport.lastResult}
         onToggleExport={handleToggleExport}
       />
     </div>

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -200,7 +200,7 @@ export function AgentVisualizer() {
   })
   useEffect(() => { setIsExporting(timelineExport.isExporting) }, [timelineExport.isExporting])
   const handleToggleExport = useCallback(() => {
-    if (timelineExport.isExporting) timelineExport.cancelExport()
+    if (timelineExport.isExporting) timelineExport.stopExport()
     else { setIsReviewing(true); timelineExport.startExport() }
   }, [timelineExport])
 

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -98,6 +98,9 @@ export interface TopBarProps {
   onTogglePanel: (panel: 'files' | 'transcript' | 'cost') => void
   onToggleTimeline: () => void
   onToggleMute: () => void
+  isExporting: boolean
+  exportProgress: number
+  onToggleExport: () => void
 }
 
 export const TopBar = memo(function TopBar({
@@ -107,6 +110,7 @@ export const TopBar = memo(function TopBar({
   agentCount, totalTokens,
   showFileAttention, showTranscript, showCostOverlay, showTimeline, isMuted,
   onTogglePanel, onToggleTimeline, onToggleMute,
+  isExporting, exportProgress, onToggleExport,
 }: TopBarProps) {
   return (
     <div className="absolute top-3 left-3 right-3 flex items-center gap-4 font-mono text-[10px]" style={{ zIndex: Z.info }}>
@@ -156,6 +160,14 @@ export const TopBar = memo(function TopBar({
 
         {/* Independent toggles */}
         <ToggleButton active={showTimeline} onClick={onToggleTimeline}>Timeline</ToggleButton>
+        <ToggleButton
+          active={isExporting}
+          onClick={onToggleExport}
+          activeColor={{ bg: COLORS.costActiveBg, text: COLORS.error }}
+          style={{ border: `1px solid ${COLORS.toggleBorder}` }}
+        >
+          {isExporting ? `● REC ${Math.round(exportProgress * 100)}%` : 'Export'}
+        </ToggleButton>
         <ToggleButton active={!isMuted} onClick={onToggleMute} style={{ border: `1px solid ${COLORS.toggleBorder}` }}>
           {isMuted ? <MutedIcon /> : <UnmutedIcon />}
         </ToggleButton>

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -100,6 +100,7 @@ export interface TopBarProps {
   onToggleMute: () => void
   isExporting: boolean
   exportProgress: number
+  exportResult: string | null
   onToggleExport: () => void
 }
 
@@ -110,7 +111,7 @@ export const TopBar = memo(function TopBar({
   agentCount, totalTokens,
   showFileAttention, showTranscript, showCostOverlay, showTimeline, isMuted,
   onTogglePanel, onToggleTimeline, onToggleMute,
-  isExporting, exportProgress, onToggleExport,
+  isExporting, exportProgress, exportResult, onToggleExport,
 }: TopBarProps) {
   return (
     <div className="absolute top-3 left-3 right-3 flex items-center gap-4 font-mono text-[10px]" style={{ zIndex: Z.info }}>
@@ -168,6 +169,7 @@ export const TopBar = memo(function TopBar({
         >
           {isExporting ? `● REC ${Math.round(exportProgress * 100)}%` : 'Export'}
         </ToggleButton>
+        {exportResult && <span style={{ color: COLORS.complete }}>{exportResult}</span>}
         <ToggleButton active={!isMuted} onClick={onToggleMute} style={{ border: `1px solid ${COLORS.toggleBorder}` }}>
           {isMuted ? <MutedIcon /> : <UnmutedIcon />}
         </ToggleButton>

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -305,6 +305,12 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     commitState(next)
   }, [commitState])
 
+  /** Move the clock forward without replaying — only safe across a stretch with no events (used by the export to skip idle gaps) */
+  const skipTo = useCallback((t: number) => {
+    const prev = frameRef.current
+    commitState({ ...prev, currentTime: t, maxTimeReached: Math.max(prev.maxTimeReached, t) })
+  }, [commitState])
+
   const setSpeed = useCallback((speed: number) => {
     frameRef.current = { ...frameRef.current, speed }
     setState(prev => ({ ...prev, speed }))
@@ -420,7 +426,7 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     currentTime: state.currentTime, isPlaying: state.isPlaying, speed: state.speed,
     maxTimeReached: state.maxTimeReached,
     conversations: state.conversations,
-    play, pause, restart, setSpeed, seekToTime,
+    play, pause, restart, setSpeed, seekToTime, skipTo,
     updateAgentPosition,
     saveSnapshot, restoreSnapshot,
   }

--- a/web/hooks/use-audio-effects.ts
+++ b/web/hooks/use-audio-effects.ts
@@ -8,6 +8,8 @@ export function useAudioEffects(
   agents: Map<string, Agent>,
   toolCalls: Map<string, ToolCallNode>,
   isReviewing: boolean,
+  /** Play (and thus record) sounds even in review mode — used by the timeline export */
+  forceOn = false,
 ) {
   const audioRef = useRef<AudioEngine | null>(null)
   const [isMuted, setIsMuted] = useState(true)
@@ -31,7 +33,7 @@ export function useAudioEffects(
 
   // Detect tool/agent state transitions and play sounds (live mode only)
   useEffect(() => {
-    if (seekingRef.current || !audioRef.current || isReviewing) return
+    if (seekingRef.current || !audioRef.current || (isReviewing && !forceOn)) return
     const audio = audioRef.current
 
     const { transitions, newAgentStates, newToolStates } = detectStateChanges(
@@ -50,7 +52,7 @@ export function useAudioEffects(
         case 'tool_error':    audio.playError(); break
       }
     }
-  }, [agents, toolCalls, isReviewing])
+  }, [agents, toolCalls, isReviewing, forceOn])
 
   const handleToggleMute = useCallback(() => {
     if (audioRef.current) {
@@ -60,5 +62,5 @@ export function useAudioEffects(
     }
   }, [])
 
-  return { isMuted, seekingRef, handleToggleMute }
+  return { isMuted, seekingRef, handleToggleMute, audioRef }
 }

--- a/web/hooks/use-timeline-export.ts
+++ b/web/hooks/use-timeline-export.ts
@@ -1,0 +1,147 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface ExportOptions {
+  getCanvas: () => HTMLCanvasElement | null
+  getAudioStream: () => MediaStream | null
+  /** Current simulation time (seconds) */
+  getCurrentTime: () => number
+  getMaxTime: () => number
+  /** Sim time of the next event still to be replayed, or null when caught up */
+  getNextEventTime: () => number | null
+  seekToTime: (t: number) => void
+  skipTo: (t: number) => void
+  play: () => void
+  pause: () => void
+  setOverlay: (text: string | null) => void
+  onDone?: () => void
+}
+
+/** Idle stretches longer than this (sim seconds) are replaced by a caption card */
+const GAP_SKIP_S = 10
+/** How long the caption card stays on screen (real ms) */
+const GAP_CARD_MS = 2000
+
+function formatGap(seconds: number): string {
+  const s = Math.round(seconds)
+  if (s < 60) return `${s}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
+  return `${Math.floor(s / 3600)}h ${String(Math.floor((s % 3600) / 60)).padStart(2, '0')}m`
+}
+
+/** Extra recording after the last event so the final animations land in the file */
+const TAIL_MS = 1500
+const FPS = 30
+
+/** Pick the best container the browser can encode; MP4 (H.264/AAC) where available, else WebM */
+function pickMimeType(): { mime: string; ext: string } {
+  const candidates: Array<[string, string]> = [
+    ['video/mp4;codecs=avc1,mp4a.40.2', 'mp4'],
+    ['video/mp4', 'mp4'],
+    ['video/webm;codecs=vp9,opus', 'webm'],
+    ['video/webm', 'webm'],
+  ]
+  for (const [mime, ext] of candidates) {
+    if (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(mime)) return { mime, ext }
+  }
+  return { mime: '', ext: 'webm' }
+}
+
+/**
+ * Records the whole timeline (from t=0 to the last event) as a video with the
+ * simulation's sounds, by replaying it in real time through a MediaRecorder
+ * fed from canvas.captureStream() + the AudioEngine's recording output.
+ * Playback speed is whatever the simulation is set to.
+ */
+export function useTimelineExport(opts: ExportOptions) {
+  const [isExporting, setIsExporting] = useState(false)
+  const [progress, setProgress] = useState(0)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const rafRef = useRef(0)
+  const discardRef = useRef(false)
+  const optsRef = useRef(opts)
+  optsRef.current = opts
+
+  const stop = useCallback((discard: boolean) => {
+    discardRef.current = discard
+    cancelAnimationFrame(rafRef.current)
+    const rec = recorderRef.current
+    if (rec && rec.state !== 'inactive') rec.stop()
+    optsRef.current.setOverlay(null)
+  }, [])
+
+  const start = useCallback(() => {
+    const o = optsRef.current
+    const canvas = o.getCanvas()
+    if (!canvas || typeof MediaRecorder === 'undefined' || !('captureStream' in canvas)) {
+      alert('Recording is not supported in this browser')
+      return
+    }
+    const { mime, ext } = pickMimeType()
+    const stream = canvas.captureStream(FPS)
+    const audio = o.getAudioStream()
+    for (const track of audio?.getAudioTracks() ?? []) stream.addTrack(track)
+
+    const chunks: Blob[] = []
+    const recorder = new MediaRecorder(stream, { ...(mime ? { mimeType: mime } : {}), videoBitsPerSecond: 6_000_000 })
+    recorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data) }
+    recorder.onstop = () => {
+      for (const track of stream.getTracks()) track.stop()
+      recorderRef.current = null
+      setIsExporting(false)
+      setProgress(0)
+      if (!discardRef.current && chunks.length > 0) {
+        const blob = new Blob(chunks, { type: recorder.mimeType || mime })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `agent-flow-${new Date().toISOString().replace(/[:.]/g, '-')}.${ext}`
+        a.click()
+        setTimeout(() => URL.revokeObjectURL(url), 10_000)
+      }
+      optsRef.current.onDone?.()
+    }
+    recorderRef.current = recorder
+    discardRef.current = false
+    setIsExporting(true)
+    setProgress(0)
+
+    // Replay from the beginning while recording
+    o.seekToTime(0)
+    o.play()
+    recorder.start(1000)
+
+    let tailTimer: ReturnType<typeof setTimeout> | null = null
+    let skipping = false
+    const tick = () => {
+      const o = optsRef.current
+      const cur = o.getCurrentTime()
+      const max = Math.max(o.getMaxTime(), 0.001)
+      setProgress(Math.min(1, cur / max))
+      if (cur >= max) {
+        if (!tailTimer) tailTimer = setTimeout(() => stop(false), TAIL_MS)
+        return
+      }
+      // Idle gap ahead: freeze, show the caption card for a moment, then jump to the next event
+      const next = o.getNextEventTime()
+      if (!skipping && next !== null && next - cur > GAP_SKIP_S) {
+        skipping = true
+        o.pause()
+        o.setOverlay(`… ${formatGap(next - cur)} later …`)
+        setTimeout(() => {
+          optsRef.current.setOverlay(null)
+          optsRef.current.skipTo(next - 0.5)
+          optsRef.current.play()
+          skipping = false
+        }, GAP_CARD_MS)
+      }
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+  }, [stop])
+
+  useEffect(() => () => { cancelAnimationFrame(rafRef.current); recorderRef.current?.stop() }, [])
+
+  return { isExporting, progress, startExport: start, cancelExport: () => stop(true) }
+}

--- a/web/hooks/use-timeline-export.ts
+++ b/web/hooks/use-timeline-export.ts
@@ -54,9 +54,38 @@ function pickMimeType(): { mime: string; ext: string } {
  * fed from canvas.captureStream() + the AudioEngine's recording output.
  * Playback speed is whatever the simulation is set to.
  */
+/** Save a blob: native "Save as" dialog where available (user picks folder + name), otherwise a download */
+async function saveBlob(blob: Blob, suggestedName: string, ext: string): Promise<string> {
+  const picker = (window as unknown as { showSaveFilePicker?: (o: unknown) => Promise<FileSystemFileHandle> }).showSaveFilePicker
+  if (picker) {
+    try {
+      const handle = await picker({
+        suggestedName,
+        types: [{ description: ext.toUpperCase() + ' video', accept: { [blob.type || `video/${ext}`]: [`.${ext}`] } }],
+      })
+      const w = await handle.createWritable()
+      await w.write(blob)
+      await w.close()
+      return `Saved as ${handle.name}`
+    } catch (err) {
+      if ((err as { name?: string }).name === 'AbortError') return 'Export cancelled (not saved)'
+      // Picker unavailable in this context — fall through to a plain download
+    }
+  }
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = suggestedName
+  a.click()
+  setTimeout(() => URL.revokeObjectURL(url), 10_000)
+  return `Saved ${suggestedName} to your browser's Downloads folder`
+}
+
 export function useTimelineExport(opts: ExportOptions) {
   const [isExporting, setIsExporting] = useState(false)
   const [progress, setProgress] = useState(0)
+  /** Human-readable outcome of the last export, cleared after a few seconds */
+  const [lastResult, setLastResult] = useState<string | null>(null)
   const recorderRef = useRef<MediaRecorder | null>(null)
   const rafRef = useRef(0)
   const discardRef = useRef(false)
@@ -93,12 +122,11 @@ export function useTimelineExport(opts: ExportOptions) {
       setProgress(0)
       if (!discardRef.current && chunks.length > 0) {
         const blob = new Blob(chunks, { type: recorder.mimeType || mime })
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = `agent-flow-${new Date().toISOString().replace(/[:.]/g, '-')}.${ext}`
-        a.click()
-        setTimeout(() => URL.revokeObjectURL(url), 10_000)
+        const name = `agent-flow-${new Date().toISOString().replace(/[:.]/g, '-')}.${ext}`
+        saveBlob(blob, name, ext).then(msg => {
+          setLastResult(`${msg} (${(blob.size / 1_048_576).toFixed(1)} MB)`)
+          setTimeout(() => setLastResult(null), 12_000)
+        })
       }
       optsRef.current.onDone?.()
     }
@@ -143,5 +171,5 @@ export function useTimelineExport(opts: ExportOptions) {
 
   useEffect(() => () => { cancelAnimationFrame(rafRef.current); recorderRef.current?.stop() }, [])
 
-  return { isExporting, progress, startExport: start, cancelExport: () => stop(true) }
+  return { isExporting, progress, lastResult, startExport: start, cancelExport: () => stop(true) }
 }

--- a/web/hooks/use-timeline-export.ts
+++ b/web/hooks/use-timeline-export.ts
@@ -52,7 +52,8 @@ function pickMimeType(): { mime: string; ext: string } {
  * Records the whole timeline (from t=0 to the last event) as a video with the
  * simulation's sounds, by replaying it in real time through a MediaRecorder
  * fed from canvas.captureStream() + the AudioEngine's recording output.
- * Playback speed is whatever the simulation is set to.
+ * Playback speed is whatever the simulation is set to. A second click stops
+ * early and saves the partial recording.
  */
 /** Save a blob: native "Save as" dialog where available (user picks folder + name), otherwise a download */
 async function saveBlob(blob: Blob, suggestedName: string, ext: string): Promise<string> {
@@ -171,5 +172,6 @@ export function useTimelineExport(opts: ExportOptions) {
 
   useEffect(() => () => { cancelAnimationFrame(rafRef.current); recorderRef.current?.stop() }, [])
 
-  return { isExporting, progress, lastResult, startExport: start, cancelExport: () => stop(true) }
+  /** Stop early and save what was recorded so far */
+  return { isExporting, progress, lastResult, startExport: start, stopExport: () => stop(false) }
 }

--- a/web/lib/audio-engine.ts
+++ b/web/lib/audio-engine.ts
@@ -7,7 +7,11 @@
 
 export class AudioEngine {
   private ctx: AudioContext | null = null
+  /** Sounds connect here at full volume; feeds both the speakers (via outputGain) and the recorder tap */
   private masterGain: GainNode | null = null
+  /** Mute stage for the speakers only, so an export still captures sound while muted */
+  private outputGain: GainNode | null = null
+  private recordDest: MediaStreamAudioDestinationNode | null = null
   private _muted = true  // default muted
   private _volume = 0.5
 
@@ -18,16 +22,30 @@ export class AudioEngine {
     }
     this.ctx = new AudioContext()
     this.masterGain = this.ctx.createGain()
-    this.masterGain.gain.value = this._muted ? 0 : this._volume
-    this.masterGain.connect(this.ctx.destination)
+    this.masterGain.gain.value = this._volume
+    this.outputGain = this.ctx.createGain()
+    this.outputGain.gain.value = this._muted ? 0 : 1
+    this.masterGain.connect(this.outputGain)
+    this.outputGain.connect(this.ctx.destination)
+  }
+
+  /** Audio stream carrying every sound the engine plays, independent of mute — for MediaRecorder */
+  recordingStream(): MediaStream | null {
+    this.ensureContext()
+    if (!this.ctx || !this.masterGain) return null
+    if (!this.recordDest) {
+      this.recordDest = this.ctx.createMediaStreamDestination()
+      this.masterGain.connect(this.recordDest)
+    }
+    return this.recordDest.stream
   }
 
   get muted() { return this._muted }
 
   setMuted(muted: boolean) {
     this._muted = muted
-    if (this.masterGain) {
-      this.masterGain.gain.setTargetAtTime(muted ? 0 : this._volume, this.ctx!.currentTime, 0.05)
+    if (this.outputGain) {
+      this.outputGain.gain.setTargetAtTime(muted ? 0 : 1, this.ctx!.currentTime, 0.05)
     }
   }
 


### PR DESCRIPTION
Adds an **Export** button to the top bar that records the whole timeline as a video file, sounds included.

How it works: the simulation is rewound to t=0 and replayed at the current speed while a `MediaRecorder` captures `canvas.captureStream()` plus the AudioEngine's output; the result is downloaded when playback reaches the last event. MP4 (H.264/AAC) where the browser can encode it (Safari, recent Chrome), WebM/VP9+Opus otherwise. Click again to cancel.

- Idle stretches longer than 10s of sim time are replaced by a 2s caption card (`… 3m 20s later …`) drawn into the canvas itself, so it ends up in the recording, then the clock skips to the next event via a new `skipTo()` that only moves time across an event-free stretch.
- Sounds are recorded even when muted: mute moved to a separate output stage and the recorder taps the mix before it. Review-mode audio gating is bypassed while exporting.
- No new dependencies. GIF is not included: it cannot carry audio, and a client-side GIF encoder would be a new dependency; happy to add it as a silent option if wanted.

https://claude.ai/code/session_01AGs5TZo6yxv7NHARHawyJf