### PR TITLE
feat: same-file collision trails across agents and sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ extension/.vscode/
 extension/package-lock.json
 
 .DS_Store
+
+# graft's local graph cache — regenerable, not committed (run `graft build`).
+graft/

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -38,7 +38,7 @@ export const BACKFILL_TURNS = 50
 /** Idle gaps between replayed transcript entries longer than this are
  *  compressed down to this length, so a session that sat idle for hours
  *  does not produce a timeline made mostly of dead time. */
-export const MAX_REPLAY_GAP_MS = 30 * 1000
+export const MAX_REPLAY_GAP_MS = 5 * 1000
 
 /** Duration of VS Code status bar messages (ms) */
 export const STATUS_MESSAGE_DURATION_MS = 5000

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -30,6 +30,11 @@ export const PERMISSION_DETECT_MS = 5000
  *  attach within ~1s of their next message. */
 export const ACTIVE_SESSION_AGE_S = 10 * 60 // 10 minutes
 
+/** How many of the most recent user turns are replayed (tool calls, subagents,
+ *  messages) when attaching to a session that already has history. Older
+ *  turns are only pre-scanned for dedup and token accounting. */
+export const BACKFILL_TURNS = 50
+
 /** Duration of VS Code status bar messages (ms) */
 export const STATUS_MESSAGE_DURATION_MS = 5000
 

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -35,6 +35,11 @@ export const ACTIVE_SESSION_AGE_S = 10 * 60 // 10 minutes
  *  turns are only pre-scanned for dedup and token accounting. */
 export const BACKFILL_TURNS = 50
 
+/** Idle gaps between replayed transcript entries longer than this are
+ *  compressed down to this length, so a session that sat idle for hours
+ *  does not produce a timeline made mostly of dead time. */
+export const MAX_REPLAY_GAP_MS = 30 * 1000
+
 /** Duration of VS Code status bar messages (ms) */
 export const STATUS_MESSAGE_DURATION_MS = 5000
 

--- a/extension/src/file-collisions.ts
+++ b/extension/src/file-collisions.ts
@@ -1,0 +1,65 @@
+/**
+ * Cross-agent / cross-session file collision detection.
+ *
+ * Every file-touching tool call is recorded per normalized path in a sliding
+ * window. When two distinct parties (session + agent) touch the same file
+ * inside the window and at least one of them writes, a collision is reported.
+ * Read-vs-read is ignored: agents grepping the same config all day is noise.
+ *
+ * One shared index per process: the standalone relay tails every session, so
+ * this is where cross-session collisions become visible.
+ */
+
+import * as path from 'path'
+
+export const COLLISION_WINDOW_MS = 90 * 1000
+
+const WRITE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit'])
+
+export interface FileTouch {
+  sessionId: string
+  agent: string
+  action: 'read' | 'write'
+  /** wall-clock ms of the touch (replay-aware) */
+  wall: number
+}
+
+export interface FileCollision {
+  file: string
+  parties: FileTouch[]
+}
+
+export function touchAction(toolName: string): 'read' | 'write' {
+  return WRITE_TOOLS.has(toolName) ? 'write' : 'read'
+}
+
+export class FileCollisionIndex {
+  private byFile = new Map<string, FileTouch[]>()
+
+  constructor(private windowMs = COLLISION_WINDOW_MS) {}
+
+  /** Record a touch; returns the collision it completes, if any. */
+  touch(file: string, touch: FileTouch): FileCollision | null {
+    const key = path.normalize(file)
+    const cutoff = touch.wall - this.windowMs
+    const recent = (this.byFile.get(key) || []).filter(t => t.wall >= cutoff)
+    // Keep one entry per party (latest wins) so the list stays tiny
+    const kept = recent.filter(t => !(t.sessionId === touch.sessionId && t.agent === touch.agent))
+    kept.push(touch)
+    this.byFile.set(key, kept)
+
+    if (kept.length < 2 || !kept.some(t => t.action === 'write')) return null
+    return { file: key, parties: kept.slice() }
+  }
+
+  /** Drop stale files so the map does not grow with every path ever seen */
+  prune(now: number): void {
+    const cutoff = now - this.windowMs
+    for (const [file, touches] of this.byFile) {
+      if (!touches.some(t => t.wall >= cutoff)) this.byFile.delete(file)
+    }
+  }
+}
+
+/** Process-wide index shared by every watcher/parser */
+export const fileCollisions = new FileCollisionIndex()

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -190,6 +190,8 @@ export interface WatchedSession {
   labelSet: boolean
   /** While replaying history: wall-clock ms of the entry being processed, so elapsed() reflects real timing */
   replayNow?: number | null
+  /** Total idle time removed from the timeline by replay gap compression (ms) */
+  compressedMs?: number
   model: string | null
   /** Maps agent names to their last emitted model ID — re-emits on model change */
   modelDetectedAgents: Map<string, string>

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -19,6 +19,7 @@ export type AgentEventType =
   | 'subagent_dispatch'
   | 'subagent_return'
   | 'permission_requested'
+  | 'file_collision'
   | 'error'
 
 export interface AgentEvent {

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -194,6 +194,8 @@ export interface WatchedSession {
   compressedMs?: number
   /** Wall-clock ms of the last processed transcript entry, for gap compression */
   lastEventWall?: number
+  /** Last value returned by elapsed(); events are never stamped earlier than this */
+  lastElapsed?: number
   model: string | null
   /** Maps agent names to their last emitted model ID — re-emits on model change */
   modelDetectedAgents: Map<string, string>

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -188,6 +188,8 @@ export interface WatchedSession {
   subagentsDir: string | null
   label: string
   labelSet: boolean
+  /** While replaying history: wall-clock ms of the entry being processed, so elapsed() reflects real timing */
+  replayNow?: number | null
   model: string | null
   /** Maps agent names to their last emitted model ID — re-emits on model change */
   modelDetectedAgents: Map<string, string>

--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -190,8 +190,10 @@ export interface WatchedSession {
   labelSet: boolean
   /** While replaying history: wall-clock ms of the entry being processed, so elapsed() reflects real timing */
   replayNow?: number | null
-  /** Total idle time removed from the timeline by replay gap compression (ms) */
+  /** Total idle time removed from the timeline by gap compression (ms) */
   compressedMs?: number
+  /** Wall-clock ms of the last processed transcript entry, for gap compression */
+  lastEventWall?: number
   model: string | null
   /** Maps agent names to their last emitted model ID — re-emits on model change */
   modelDetectedAgents: Map<string, string>

--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -563,7 +563,7 @@ export class SessionWatcher implements AgentSessionWatcher {
     if (sessionId) {
       const session = this.sessions.get(sessionId)
       if (session) {
-        return ((session.replayNow ?? Date.now()) - session.sessionStartTime) / 1000
+        return ((session.replayNow ?? Date.now()) - session.sessionStartTime - (session.compressedMs ?? 0)) / 1000
       }
     }
     return 0

--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -442,12 +442,16 @@ export class SessionWatcher implements AgentSessionWatcher {
     }, sessionId)
     session.sessionDetected = true
 
-    // Emit initial context breakdown from prescan so the webview shows accumulated tokens
-    this.emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
-
     // Replay the recent turns through the live path so the webview shows
     // tool calls, subagents and messages that happened before we attached.
+    // Must come before any elapsed()-timed event: the clock is only compressed
+    // as the replay advances, and an early event at "now" would push the
+    // frontend clock past every replayed one.
     this.parser.replayLines(replayLines, session, sessionId)
+    this.parser.advanceClock(session, Date.now()) // compress the gap between last entry and now
+
+    // Emit context breakdown so the webview shows accumulated tokens
+    this.emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
 
     // Watch for new content
     session.fileWatcher = fs.watch(filePath, (eventType) => {
@@ -482,6 +486,7 @@ export class SessionWatcher implements AgentSessionWatcher {
     const result = readNewFileLines(session.filePath, session.fileSize)
     if (!result) return
     session.fileSize = result.newSize
+    if (result.lines.length > 0) this.parser.advanceClock(session, Date.now())
     for (const line of result.lines) {
       this.parser.processTranscriptLine(line, ORCHESTRATOR_NAME, session.pendingToolCalls, session.seenToolUseIds, sessionId, session.seenMessageHashes)
     }

--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -568,7 +568,11 @@ export class SessionWatcher implements AgentSessionWatcher {
     if (sessionId) {
       const session = this.sessions.get(sessionId)
       if (session) {
-        return ((session.replayNow ?? Date.now()) - session.sessionStartTime - (session.compressedMs ?? 0)) / 1000
+        const raw = ((session.replayNow ?? Date.now()) - session.sessionStartTime - (session.compressedMs ?? 0)) / 1000
+        // Timer- and subagent-driven emitters read the clock between advanceClock() calls;
+        // clamp so no event is ever stamped earlier than the previous one
+        session.lastElapsed = Math.max(raw, session.lastElapsed ?? 0)
+        return session.lastElapsed
       }
     }
     return 0
@@ -576,6 +580,7 @@ export class SessionWatcher implements AgentSessionWatcher {
 
   /** Emit a context_update event with cumulative token breakdown */
   private emitContextUpdate(agentName: string, session: WatchedSession, sessionId?: string): void {
+    if (session.replayNow != null) return // one context_update is emitted after the replay instead of one per line
     const bd = session.contextBreakdown
     const total = bd.systemPrompt + bd.userMessages + bd.toolResults + bd.reasoning + bd.subagentResults
     this.emit({

--- a/extension/src/session-watcher.ts
+++ b/extension/src/session-watcher.ts
@@ -417,14 +417,14 @@ export class SessionWatcher implements AgentSessionWatcher {
 
     const stat = fs.statSync(filePath)
 
-    // Pre-scan existing content for dedup IDs + collect recent entries for catch-up
-    const catchUpEntries = this.parser.prescanExistingContent(filePath, stat.size, session)
+    // Pre-scan older history for dedup IDs; keep the recent turns for replay
+    const { entries, replayLines } = this.parser.prepareBackfill(filePath, stat.size, session)
 
     // Start from current end — only process NEW events going forward
     session.fileSize = stat.size
 
-    // Extract session label from the first user message in catch-up entries
-    this.parser.extractSessionLabel(catchUpEntries, session)
+    // Extract session label from the first user message in pre-scanned entries
+    this.parser.extractSessionLabel(entries, session)
 
     // Emit session start
     this._onSessionDetected.fire(sessionId)
@@ -445,10 +445,9 @@ export class SessionWatcher implements AgentSessionWatcher {
     // Emit initial context breakdown from prescan so the webview shows accumulated tokens
     this.emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
 
-    // Emit catch-up messages for content that was already in the file when we detected
-    // the session (e.g. the first user message). These were pre-scanned for dedup/tokens
-    // but never emitted as events. Emit them now so the webview shows the full history.
-    this.parser.emitCatchUpEntries(catchUpEntries, session, sessionId)
+    // Replay the recent turns through the live path so the webview shows
+    // tool calls, subagents and messages that happened before we attached.
+    this.parser.replayLines(replayLines, session, sessionId)
 
     // Watch for new content
     session.fileWatcher = fs.watch(filePath, (eventType) => {
@@ -564,7 +563,7 @@ export class SessionWatcher implements AgentSessionWatcher {
     if (sessionId) {
       const session = this.sessions.get(sessionId)
       if (session) {
-        return (Date.now() - session.sessionStartTime) / 1000
+        return ((session.replayNow ?? Date.now()) - session.sessionStartTime) / 1000
       }
     }
     return 0

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -27,6 +27,7 @@ import {
 import { summarizeInput, summarizeResult, extractInputData, detectError, buildDiscovery } from './tool-summarizer'
 import { estimateTokensFromContent, estimateTokensFromText } from './token-estimator'
 import { createLogger } from './logger'
+import { fileCollisions, touchAction } from './file-collisions'
 
 const log = createLogger('TranscriptParser')
 
@@ -305,6 +306,8 @@ export class TranscriptParser {
       startTime: Date.now(),
     })
 
+    if (filePath && sessionId) this.detectFileCollision(filePath, toolName, agentName, sessionId)
+
     // Check if this is a subagent call (Task in older Claude Code, Agent in newer versions)
     if (toolName === 'Task' || toolName === 'Agent') {
       const childName = resolveSubagentChildName(block.input)
@@ -328,6 +331,23 @@ export class TranscriptParser {
         inputData: extractInputData(toolName, block.input),
       },
     }, sessionId)
+  }
+
+  /** Report when this touch completes a same-file collision with another agent or session */
+  private detectFileCollision(filePath: string, toolName: string, agentName: string, sessionId: string): void {
+    const session = this.delegate.getSession(sessionId)
+    const wall = session?.replayNow ?? Date.now()
+    const collision = fileCollisions.touch(filePath, { sessionId, agent: agentName, action: touchAction(toolName), wall })
+    if (!collision) return
+    const sessions = [...new Set(collision.parties.map(p => p.sessionId))]
+    // Every involved session gets the event so each canvas/tab can show it
+    for (const sid of sessions) {
+      this.delegate.emit({
+        time: this.delegate.elapsed(sid),
+        type: 'file_collision',
+        payload: { file: collision.file, parties: collision.parties, sessions },
+      }, sid)
+    }
   }
 
   handleToolResult(

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -21,6 +21,7 @@ import {
   SYSTEM_CONTENT_PREFIXES,
   generateSubagentFallbackName,
   resolveSubagentChildName,
+  BACKFILL_TURNS,
 } from './constants'
 import { summarizeInput, summarizeResult, extractInputData, detectError, buildDiscovery } from './tool-summarizer'
 import { estimateTokensFromContent, estimateTokensFromText } from './token-estimator'
@@ -34,6 +35,18 @@ export interface TranscriptParserDelegate {
   getSession(sessionId: string): WatchedSession | undefined
   fireSessionLifecycle(event: { type: 'started' | 'ended' | 'updated'; sessionId: string; label: string }): void
   emitContextUpdate(agentName: string, session: WatchedSession, sessionId?: string): void
+}
+
+/** Wall-clock ms of a transcript line, without a full JSON parse. */
+function lineTimestamp(line: string | undefined): number | null {
+  const m = line?.match(/"timestamp":"([^"]+)"/)
+  const ts = m ? Date.parse(m[1]) : NaN
+  return Number.isNaN(ts) ? null : ts
+}
+
+/** ponytail: string sniff instead of JSON.parse — tool_result entries are also type "user", exclude them */
+function isUserTurnLine(line: string): boolean {
+  return line.includes('"type":"user"') && !line.includes('"tool_result"')
 }
 
 /** Type guard: check if a value is a non-null object */
@@ -423,20 +436,50 @@ export class TranscriptParser {
   }
 
   /**
-   * Pre-scan existing file content:
-   * 1. Build seenToolUseIds dedup set (prevents re-emitting old tool calls)
-   * 2. Return all entries for catch-up emission
+   * Split existing file content for session attach:
+   * - everything before the last BACKFILL_TURNS user turns is pre-scanned only
+   *   (dedup sets + token accounting, nothing emitted)
+   * - the tail is returned as raw lines for replayLines(), which runs them
+   *   through the live path so tool calls, subagents and messages show up
+   * Also pins the session clock to the first transcript entry so replayed and
+   * live events share a real timeline.
    */
-  prescanExistingContent(filePath: string, size: number, session: WatchedSession): TranscriptEntry[] {
-    if (size === 0) { return [] }
-    const catchUpEntries: TranscriptEntry[] = []
+  prepareBackfill(filePath: string, size: number, session: WatchedSession): { entries: TranscriptEntry[]; replayLines: string[] } {
+    if (size === 0) { return { entries: [], replayLines: [] } }
+    let lines: string[]
     try {
       // Read only up to `size` bytes — the file may have grown since stat.
       // Reading beyond would add tool_use IDs to the dedup set that haven't
       // been accounted for in fileSize, causing readNewLines to silently skip them.
-      const content = readFileChunk(filePath, 0, size)
-      for (const line of content.split(/\r?\n/)) {
-        if (!line.trim()) { continue }
+      lines = readFileChunk(filePath, 0, size).split(/\r?\n/).filter(l => l.trim())
+    } catch (err) {
+      log.error('Pre-scan failed:', err)
+      return { entries: [], replayLines: [] }
+    }
+    const firstTs = lineTimestamp(lines[0])
+    if (firstTs) { session.sessionStartTime = firstTs }
+    let split = lines.length
+    for (let i = lines.length - 1, turns = 0; i >= 0 && turns < BACKFILL_TURNS; i--) {
+      if (isUserTurnLine(lines[i])) { turns++; split = i }
+    }
+    return { entries: this.prescanLines(lines.slice(0, split), session), replayLines: lines.slice(split) }
+  }
+
+  /** Replay historical lines through the live path, with the session clock
+   *  pinned to each entry's own timestamp so durations and the timeline are real. */
+  replayLines(lines: string[], session: WatchedSession, sessionId: string): void {
+    for (const line of lines) {
+      session.replayNow = lineTimestamp(line)
+      this.processTranscriptLine(line, ORCHESTRATOR_NAME, session.pendingToolCalls, session.seenToolUseIds, sessionId, session.seenMessageHashes)
+    }
+    session.replayNow = null
+  }
+
+  /** Build dedup sets and accumulate token counts for lines that will NOT be emitted. */
+  private prescanLines(lines: string[], session: WatchedSession): TranscriptEntry[] {
+    const catchUpEntries: TranscriptEntry[] = []
+    {
+      for (const line of lines) {
         try {
           const entry = JSON.parse(line.trim()) as TranscriptEntry
           // Build dedup sets for tool_use blocks and messages + accumulate token counts
@@ -504,57 +547,8 @@ export class TranscriptParser {
         } catch (err) { log.debug('Skipping unparseable transcript line:', err) }
       }
       log.info(`Pre-scanned ${session.seenToolUseIds.size} existing tool_use IDs, ${catchUpEntries.length} entries total`)
-
-      return catchUpEntries
-    } catch (err) {
-      log.error('Pre-scan failed:', err)
-      return []
     }
-  }
-
-  /** Emit message events for pre-existing transcript entries (catch-up on session detection).
-   *  Only emits the last user message (the current turn), not the full history. */
-  emitCatchUpEntries(entries: TranscriptEntry[], session: WatchedSession, sessionId: string): void {
-    // Find the last user entry — that's the current turn
-    let lastUserIndex = -1
-    for (let i = entries.length - 1; i >= 0; i--) {
-      if (entries[i].type === 'user') { lastUserIndex = i; break }
-    }
-    if (lastUserIndex === -1) { return }
-    const recentEntries = entries.slice(lastUserIndex)
-
-    for (const entry of recentEntries) {
-      const role = entry.type === 'user' ? 'user' : 'assistant'
-      const msg = entry.message
-      if (!msg) { continue }
-
-      // String content (common for user messages)
-      if (typeof msg.content === 'string' && msg.content.trim()) {
-        const text = msg.content.trim()
-        if (this.isSystemInjectedContent(text)) { continue }
-        this.delegate.emit({
-          time: 0,
-          type: 'message',
-          payload: { agent: ORCHESTRATOR_NAME, role, content: text.slice(0, MESSAGE_MAX) },
-        }, sessionId)
-        continue
-      }
-
-      // Array content (text blocks, thinking blocks, tool_use blocks)
-      if (!Array.isArray(msg.content)) { continue }
-      for (const block of msg.content) {
-        if (block.type === 'text' && 'text' in block) {
-          const text = safeText(block)
-          if (text && !this.isSystemInjectedContent(text)) {
-            this.delegate.emit({
-              time: 0,
-              type: 'message',
-              payload: { agent: ORCHESTRATOR_NAME, role, content: text.slice(0, MESSAGE_MAX) },
-            }, sessionId)
-          }
-        }
-      }
-    }
+    return catchUpEntries
   }
 
   /** Extract a human-readable label from the first user message in transcript entries */

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -22,6 +22,7 @@ import {
   generateSubagentFallbackName,
   resolveSubagentChildName,
   BACKFILL_TURNS,
+  MAX_REPLAY_GAP_MS,
 } from './constants'
 import { summarizeInput, summarizeResult, extractInputData, detectError, buildDiscovery } from './tool-summarizer'
 import { estimateTokensFromContent, estimateTokensFromText } from './token-estimator'
@@ -473,8 +474,15 @@ export class TranscriptParser {
   /** Replay historical lines through the live path, with the session clock
    *  pinned to each entry's own timestamp so durations and the timeline are real. */
   replayLines(lines: string[], session: WatchedSession, sessionId: string): void {
+    let prevTs: number | null = null
     for (const line of lines) {
-      session.replayNow = lineTimestamp(line)
+      const ts = lineTimestamp(line)
+      // Compress idle gaps: elapsed() subtracts compressedMs, for replayed and live events alike
+      if (ts && prevTs && ts - prevTs > MAX_REPLAY_GAP_MS) {
+        session.compressedMs = (session.compressedMs ?? 0) + (ts - prevTs - MAX_REPLAY_GAP_MS)
+      }
+      if (ts) prevTs = ts
+      session.replayNow = ts
       this.processTranscriptLine(line, ORCHESTRATOR_NAME, session.pendingToolCalls, session.seenToolUseIds, sessionId, session.seenMessageHashes)
     }
     session.replayNow = null

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -474,18 +474,25 @@ export class TranscriptParser {
   /** Replay historical lines through the live path, with the session clock
    *  pinned to each entry's own timestamp so durations and the timeline are real. */
   replayLines(lines: string[], session: WatchedSession, sessionId: string): void {
-    let prevTs: number | null = null
     for (const line of lines) {
       const ts = lineTimestamp(line)
-      // Compress idle gaps: elapsed() subtracts compressedMs, for replayed and live events alike
-      if (ts && prevTs && ts - prevTs > MAX_REPLAY_GAP_MS) {
-        session.compressedMs = (session.compressedMs ?? 0) + (ts - prevTs - MAX_REPLAY_GAP_MS)
-      }
-      if (ts) prevTs = ts
+      if (ts) this.advanceClock(session, ts)
       session.replayNow = ts
       this.processTranscriptLine(line, ORCHESTRATOR_NAME, session.pendingToolCalls, session.seenToolUseIds, sessionId, session.seenMessageHashes)
     }
     session.replayNow = null
+  }
+
+  /** Move the session clock to `wallMs`, compressing any idle gap longer than
+   *  MAX_REPLAY_GAP_MS. elapsed() subtracts compressedMs, so replayed and live
+   *  events share one continuous timeline without dead time. Call before
+   *  processing new lines, both during replay and live. */
+  advanceClock(session: WatchedSession, wallMs: number): void {
+    const last = session.lastEventWall
+    if (last && wallMs - last > MAX_REPLAY_GAP_MS) {
+      session.compressedMs = (session.compressedMs ?? 0) + (wallMs - last - MAX_REPLAY_GAP_MS)
+    }
+    if (!last || wallMs > last) session.lastEventWall = wallMs
   }
 
   /** Build dedup sets and accumulate token counts for lines that will NOT be emitted. */

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -456,8 +456,13 @@ export class TranscriptParser {
       log.error('Pre-scan failed:', err)
       return { entries: [], replayLines: [] }
     }
-    const firstTs = lineTimestamp(lines[0])
-    if (firstTs) { session.sessionStartTime = firstTs }
+    // First line WITH a timestamp — sessions start with ai-title/mode/summary lines that carry none.
+    // Without this the replay clock would be "now", elapsed() negative, and the
+    // frontend would collapse every replayed event onto the same instant.
+    for (const line of lines) {
+      const ts = lineTimestamp(line)
+      if (ts) { session.sessionStartTime = ts; break }
+    }
     let split = lines.length
     for (let i = lines.length - 1, turns = 0; i >= 0 && turns < BACKFILL_TURNS; i--) {
       if (isUserTurnLine(lines[i])) { turns++; split = i }

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -38,11 +38,20 @@ export interface TranscriptParserDelegate {
   emitContextUpdate(agentName: string, session: WatchedSession, sessionId?: string): void
 }
 
-/** Wall-clock ms of a transcript line, without a full JSON parse. */
+/** Line types whose top-level timestamp reflects conversation time. Other lines
+ *  (file-history-snapshot, queue-operation, attachment...) carry nested or
+ *  out-of-order timestamps and must not drive the clock. */
+const CLOCK_LINE_TYPES = new Set(['user', 'assistant', 'progress', 'system'])
+
+/** Wall-clock ms of a conversation transcript line (top-level `timestamp` only). */
 function lineTimestamp(line: string | undefined): number | null {
-  const m = line?.match(/"timestamp":"([^"]+)"/)
-  const ts = m ? Date.parse(m[1]) : NaN
-  return Number.isNaN(ts) ? null : ts
+  if (!line || !line.includes('"timestamp"')) return null
+  try {
+    const parsed = JSON.parse(line) as { type?: unknown; timestamp?: unknown }
+    if (typeof parsed.type !== 'string' || !CLOCK_LINE_TYPES.has(parsed.type)) return null
+    const ts = typeof parsed.timestamp === 'string' ? Date.parse(parsed.timestamp) : NaN
+    return Number.isNaN(ts) ? null : ts
+  } catch { return null }
 }
 
 /** ponytail: string sniff instead of JSON.parse — tool_result entries are also type "user", exclude them */
@@ -481,7 +490,9 @@ export class TranscriptParser {
     for (const line of lines) {
       const ts = lineTimestamp(line)
       if (ts) this.advanceClock(session, ts)
-      session.replayNow = ts
+      // Transcript lines are not strictly ordered (queued messages, attachments);
+      // never let the replay clock move backwards
+      session.replayNow = ts ? Math.max(ts, session.lastEventWall ?? ts) : session.lastEventWall ?? null
       this.processTranscriptLine(line, ORCHESTRATOR_NAME, session.pendingToolCalls, session.seenToolUseIds, sessionId, session.seenMessageHashes)
     }
     session.replayNow = null
@@ -492,6 +503,7 @@ export class TranscriptParser {
    *  events share one continuous timeline without dead time. Call before
    *  processing new lines, both during replay and live. */
   advanceClock(session: WatchedSession, wallMs: number): void {
+    wallMs = Math.min(wallMs, Date.now()) // a bogus future timestamp must not stall the clock
     const last = session.lastEventWall
     if (last && wallMs - last > MAX_REPLAY_GAP_MS) {
       session.compressedMs = (session.compressedMs ?? 0) + (wallMs - last - MAX_REPLAY_GAP_MS)

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -464,6 +464,10 @@ export class TranscriptParser {
       const ts = lineTimestamp(line)
       if (ts) { session.sessionStartTime = ts; break }
     }
+    // Seed the gap-compression clock at session start, so the stretch covered
+    // by pre-scanned (not replayed) turns collapses too instead of showing up
+    // as thousands of empty minutes before the first replayed event.
+    session.lastEventWall = session.sessionStartTime
     let split = lines.length
     for (let i = lines.length - 1, turns = 0; i >= 0 && turns < BACKFILL_TURNS; i--) {
       if (isUserTurnLine(lines[i])) { turns++; split = i }

--- a/scripts/file-collisions.test.ts
+++ b/scripts/file-collisions.test.ts
@@ -1,0 +1,41 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { FileCollisionIndex, touchAction } from '../extension/src/file-collisions'
+
+test('read vs read on the same file is not a collision', () => {
+  const idx = new FileCollisionIndex(90_000)
+  assert.equal(idx.touch('/p/a.ts', { sessionId: 's1', agent: 'orchestrator', action: 'read', wall: 1000 }), null)
+  assert.equal(idx.touch('/p/a.ts', { sessionId: 's2', agent: 'orchestrator', action: 'read', wall: 2000 }), null)
+})
+
+test('write after another party read inside the window is a collision with both parties', () => {
+  const idx = new FileCollisionIndex(90_000)
+  idx.touch('/p/a.ts', { sessionId: 's1', agent: 'orchestrator', action: 'read', wall: 1000 })
+  const c = idx.touch('/p/a.ts', { sessionId: 's2', agent: 'orchestrator', action: 'write', wall: 5000 })
+  assert.ok(c)
+  assert.equal(c.parties.length, 2)
+  assert.deepEqual([...new Set(c.parties.map(p => p.sessionId))].sort(), ['s1', 's2'])
+})
+
+test('same session, two subagents, one writes: collision', () => {
+  const idx = new FileCollisionIndex(90_000)
+  idx.touch('/p/a.ts', { sessionId: 's1', agent: 'find:clock', action: 'write', wall: 1000 })
+  const c = idx.touch('/p/a.ts', { sessionId: 's1', agent: 'find:relay', action: 'read', wall: 1500 })
+  assert.ok(c)
+  assert.deepEqual(c.parties.map(p => p.agent).sort(), ['find:clock', 'find:relay'])
+})
+
+test('same party touching twice is not a collision, and touches outside the window expire', () => {
+  const idx = new FileCollisionIndex(90_000)
+  idx.touch('/p/a.ts', { sessionId: 's1', agent: 'orchestrator', action: 'write', wall: 1000 })
+  assert.equal(idx.touch('/p/a.ts', { sessionId: 's1', agent: 'orchestrator', action: 'write', wall: 2000 }), null)
+  // s2 arrives 5 minutes later: s1's touch is stale
+  assert.equal(idx.touch('/p/a.ts', { sessionId: 's2', agent: 'orchestrator', action: 'write', wall: 2000 + 300_000 }), null)
+})
+
+test('touchAction classifies editing tools as writes', () => {
+  assert.equal(touchAction('Edit'), 'write')
+  assert.equal(touchAction('Write'), 'write')
+  assert.equal(touchAction('Read'), 'read')
+  assert.equal(touchAction('Grep'), 'read')
+})

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -500,18 +500,12 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
         sendSSE(res, { type: 'session-list', sessions: sessionList })
       }
 
-      // Replay buffered events for the most recent active session
-      const sorted = [...sessionList].sort((a, b) => {
-        const aActive = a.status === 'active' ? 1 : 0
-        const bActive = b.status === 'active' ? 1 : 0
-        if (aActive !== bActive) return bActive - aActive
-        return b.lastActivityTime - a.lastActivityTime
-      })
-      if (sorted.length > 0) {
-        const buffered = eventBuffer.get(sorted[0].id)
-        if (buffered) {
-          sendSSE(res, { type: 'agent-event-batch', events: buffered })
-        }
+      // Replay buffered events for every session — the frontend buffers them
+      // per session and flushes on selection, so switching tabs shows history
+      // even for sessions attached before this client connected.
+      for (const s of sessionList) {
+        const buffered = eventBuffer.get(s.id)
+        if (buffered) sendSSE(res, { type: 'agent-event-batch', events: buffered })
       }
     },
 

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -61,15 +61,24 @@ function log(...args: unknown[]) {
 
 const sseClients = new Set<http.ServerResponse>()
 
-function sendSSE(res: http.ServerResponse, data: unknown) {
-  try { res.write(`data: ${JSON.stringify(data)}\n\n`) } catch {
+// SSE ids let a reconnecting EventSource resume from where it left off
+// (Last-Event-ID) instead of receiving every session's history again.
+// BOOT_ID changes on every relay start so a stale id triggers a full reset.
+const BOOT_ID = Math.random().toString(36).slice(2, 10)
+let seq = 0
+
+function sendSSE(res: http.ServerResponse, data: unknown, id?: number) {
+  try {
+    res.write(`${id !== undefined ? `id: ${BOOT_ID}:${id}\n` : ''}data: ${JSON.stringify(data)}\n\n`)
+  } catch {
     sseClients.delete(res)
   }
 }
 
-function broadcast(data: string) {
+function broadcast(data: string, id?: number) {
+  const frame = `${id !== undefined ? `id: ${BOOT_ID}:${id}\n` : ''}data: ${data}\n\n`
   for (const res of sseClients) {
-    try { res.write(`data: ${data}\n\n`) } catch {
+    try { res.write(frame) } catch {
       sseClients.delete(res)
     }
   }
@@ -77,7 +86,14 @@ function broadcast(data: string) {
 
 // ─── Event buffering ────────────────────────────────────────────────────────
 
-const eventBuffer = new Map<string, AgentEvent[]>()
+interface BufferedEvent { seq: number; event: AgentEvent }
+const eventBuffer = new Map<string, BufferedEvent[]>()
+
+/** Events a late client cannot do without: everything else references these agents */
+const STRUCTURAL_EVENTS = new Set<string>(['agent_spawn', 'subagent_dispatch', 'model_detected'])
+
+/** While non-null, broadcastEvent() collects instead of sending — used to ship a replay as ONE batch frame */
+let replayBatch: AgentEvent[] | null = null
 
 function broadcastEvent(event: AgentEvent) {
   sessionEventCount++
@@ -88,16 +104,21 @@ function broadcastEvent(event: AgentEvent) {
   const sid = event.sessionId?.slice(0, SESSION_ID_DISPLAY) || '?'
   log(`[event] ${event.type} (session ${sid})`)
 
+  const id = ++seq
   if (event.sessionId) {
     let buf = eventBuffer.get(event.sessionId) || []
-    buf.push(event)
+    buf.push({ seq: id, event })
     if (buf.length > MAX_EVENT_BUFFER) {
-      buf = buf.slice(buf.length - MAX_EVENT_BUFFER)
+      // Trim the oldest events but keep structural ones (spawns, models):
+      // without them a late client gets a batch that references unknown agents
+      const dropped = buf.slice(0, buf.length - MAX_EVENT_BUFFER).filter(b => STRUCTURAL_EVENTS.has(b.event.type))
+      buf = dropped.concat(buf.slice(buf.length - MAX_EVENT_BUFFER))
     }
     eventBuffer.set(event.sessionId, buf)
   }
 
-  broadcast(JSON.stringify({ type: 'agent-event', event }))
+  if (replayBatch) { replayBatch.push(event); return }
+  broadcast(JSON.stringify({ type: 'agent-event', event }), id)
 }
 
 function broadcastSessionLifecycle(type: 'started' | 'ended' | 'updated', sessionId: string, label: string) {
@@ -120,12 +141,19 @@ const sessions = new Map<string, WatchedSession>()
 function elapsed(sessionId?: string): number {
   if (sessionId) {
     const session = sessions.get(sessionId)
-    if (session) return ((session.replayNow ?? Date.now()) - session.sessionStartTime - (session.compressedMs ?? 0)) / 1000
+    if (session) {
+      const raw = ((session.replayNow ?? Date.now()) - session.sessionStartTime - (session.compressedMs ?? 0)) / 1000
+      // Timer- and subagent-driven emitters read the clock between advanceClock() calls;
+      // clamp so no event is ever stamped earlier than the previous one
+      session.lastElapsed = Math.max(raw, session.lastElapsed ?? 0)
+      return session.lastElapsed
+    }
   }
   return 0
 }
 
 function emitContextUpdate(agentName: string, session: WatchedSession, sessionId?: string) {
+  if (session.replayNow != null) return // one context_update is emitted after the replay instead of one per line
   const bd = session.contextBreakdown
   const total = bd.systemPrompt + bd.userMessages + bd.toolResults + bd.reasoning + bd.subagentResults
   broadcastEvent({
@@ -227,9 +255,15 @@ function watchSession(sessionId: string, filePath: string) {
   })
   session.sessionDetected = true
 
+  // Ship the whole replay as one frame: thousands of individual SSE messages
+  // would trickle onto the canvas over many animation frames and look like playback
+  replayBatch = []
   parser.replayLines(replayLines, session, sessionId)
   parser.advanceClock(session, Date.now()) // compress the gap between last entry and now
   emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
+  const batch = replayBatch
+  replayBatch = null
+  if (batch.length > 0) broadcast(JSON.stringify({ type: 'agent-event-batch', events: batch }), seq)
 
   session.fileWatcher = fs.watch(filePath, (eventType) => {
     if (eventType === 'change') readNewLines(sessionId)
@@ -487,6 +521,15 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
         log(`[sse] Client disconnected (${sseClients.size} total)`)
       })
 
+      // A reconnecting client sends Last-Event-ID: same boot → only what it missed;
+      // different boot (relay restarted) → tell it to reset, then send everything.
+      let afterSeq = -1
+      const lastId = String(req.headers['last-event-id'] || '')
+      if (lastId) {
+        const [boot, n] = lastId.split(':')
+        if (boot === BOOT_ID && Number.isFinite(Number(n))) afterSeq = Number(n)
+        else sendSSE(res, { type: 'reset', reason: 'relay-restarted' })
+      }
       // Send current session list (Claude + Codex)
       const sessionList: SessionInfo[] = []
       for (const session of sessions.values()) {
@@ -506,8 +549,8 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
       // per session and flushes on selection, so switching tabs shows history
       // even for sessions attached before this client connected.
       for (const s of sessionList) {
-        const buffered = eventBuffer.get(s.id)
-        if (buffered) sendSSE(res, { type: 'agent-event-batch', events: buffered })
+        const buffered = (eventBuffer.get(s.id) || []).filter(b => b.seq > afterSeq)
+        if (buffered.length > 0) sendSSE(res, { type: 'agent-event-batch', events: buffered.map(b => b.event) }, buffered[buffered.length - 1].seq)
       }
     },
 

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -120,7 +120,7 @@ const sessions = new Map<string, WatchedSession>()
 function elapsed(sessionId?: string): number {
   if (sessionId) {
     const session = sessions.get(sessionId)
-    if (session) return ((session.replayNow ?? Date.now()) - session.sessionStartTime) / 1000
+    if (session) return ((session.replayNow ?? Date.now()) - session.sessionStartTime - (session.compressedMs ?? 0)) / 1000
   }
   return 0
 }

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -227,8 +227,9 @@ function watchSession(sessionId: string, filePath: string) {
   })
   session.sessionDetected = true
 
-  emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
   parser.replayLines(replayLines, session, sessionId)
+  parser.advanceClock(session, Date.now()) // compress the gap between last entry and now
+  emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
 
   session.fileWatcher = fs.watch(filePath, (eventType) => {
     if (eventType === 'change') readNewLines(sessionId)
@@ -256,6 +257,7 @@ function readNewLines(sessionId: string) {
   const result = readNewFileLines(session.filePath, session.fileSize)
   if (!result) return
   session.fileSize = result.newSize
+  if (result.lines.length > 0) parser.advanceClock(session, Date.now())
   for (const line of result.lines) {
     parser.processTranscriptLine(line, ORCHESTRATOR_NAME, session.pendingToolCalls, session.seenToolUseIds, sessionId, session.seenMessageHashes)
   }

--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -120,7 +120,7 @@ const sessions = new Map<string, WatchedSession>()
 function elapsed(sessionId?: string): number {
   if (sessionId) {
     const session = sessions.get(sessionId)
-    if (session) return (Date.now() - session.sessionStartTime) / 1000
+    if (session) return ((session.replayNow ?? Date.now()) - session.sessionStartTime) / 1000
   }
   return 0
 }
@@ -215,9 +215,9 @@ function watchSession(sessionId: string, filePath: string) {
   sessions.set(sessionId, session)
 
   const stat = fs.statSync(filePath)
-  const catchUpEntries = parser.prescanExistingContent(filePath, stat.size, session)
+  const { entries, replayLines } = parser.prepareBackfill(filePath, stat.size, session)
   session.fileSize = stat.size
-  parser.extractSessionLabel(catchUpEntries, session)
+  parser.extractSessionLabel(entries, session)
 
   broadcastSessionLifecycle('started', sessionId, session.label)
   broadcastEvent({
@@ -228,7 +228,7 @@ function watchSession(sessionId: string, filePath: string) {
   session.sessionDetected = true
 
   emitContextUpdate(ORCHESTRATOR_NAME, session, sessionId)
-  parser.emitCatchUpEntries(catchUpEntries, session, sessionId)
+  parser.replayLines(replayLines, session, sessionId)
 
   session.fileWatcher = fs.watch(filePath, (eventType) => {
     if (eventType === 'change') readNewLines(sessionId)

--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -4,6 +4,7 @@ import { useRef, useEffect, useState, useCallback } from 'react'
 import { Agent, Particle, Edge, Discovery, DepthParticle } from '@/lib/agent-types'
 import type { SimulationState } from '@/hooks/simulation/types'
 import { getStateColor } from '@/lib/colors'
+import { drawCollisions, type CanvasCollision } from './canvas/draw-collisions'
 import { ANIM_SPEED, PERF_OVERLAY, PERF_OVERLAY_ENABLED } from '@/lib/canvas-constants'
 import { BloomRenderer } from './bloom-renderer'
 import { createDepthParticles, updateDepthParticles, drawBackground } from './background-layer'
@@ -41,12 +42,15 @@ interface CanvasProps {
   onDiscoveryClick?: (discoveryId: string | null) => void
   selectedDiscoveryId?: string | null
   showCostOverlay?: boolean
+  /** Same-file collisions involving agents of this session */
+  collisions?: CanvasCollision[]
 }
 
 export function AgentCanvas({
   simulationRef,
   selectedAgentId, hoveredAgentId, showStats, showHexGrid, zoomToFitTrigger, pauseAutoFit,
   onAgentClick, onAgentHover, onAgentDrag, onContextMenu, onToolCallClick, selectedToolCallId, onDiscoveryClick, selectedDiscoveryId, showCostOverlay,
+  collisions,
 }: CanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const mainCanvasRef = useRef<HTMLCanvasElement>(null)
@@ -93,7 +97,7 @@ export function AgentCanvas({
     agents: sim.agents, toolCalls: sim.toolCalls,
     particles: sim.particles, edges: sim.edges, discoveries: sim.discoveries,
     selectedAgentId, hoveredAgentId, showStats, showHexGrid,
-    showCostOverlay, selectedToolCallId, selectedDiscoveryId,
+    showCostOverlay, selectedToolCallId, selectedDiscoveryId, collisions,
     simTime: sim.currentTime, pauseAutoFit, dimensions,
     onAgentDrag, onAgentClick, onAgentHover, onContextMenu,
     onToolCallClick, onDiscoveryClick,
@@ -267,6 +271,7 @@ export function AgentCanvas({
 
       drawDiscoveryConnections(ctx, discoveries, agents)
       drawEdges(ctx, edges, agents, toolCalls, activeEdgeIds, timeRef.current)
+      if (drawPropsRef.current.collisions?.length) drawCollisions(ctx, drawPropsRef.current.collisions, agents, timeRef.current)
       drawToolCalls(ctx, toolCalls, timeRef.current, selectedToolCallId)
       drawDiscoveries(ctx, discoveries, agents, selectedDiscoveryId)
       drawAgents(ctx, agents, selectedAgentId, hoveredAgentId, showStats, timeRef.current)

--- a/web/components/agent-visualizer/canvas/draw-collisions.ts
+++ b/web/components/agent-visualizer/canvas/draw-collisions.ts
@@ -1,0 +1,56 @@
+import type { Agent } from '@/lib/agent-types'
+import { COLORS } from '@/lib/colors'
+
+export interface CanvasCollision {
+  file: string
+  /** agent names present in this canvas */
+  agents: string[]
+  /** true when at least one party in another session is involved too */
+  crossSession: boolean
+  /** 0..1 freshness, 1 = just happened */
+  freshness: number
+}
+
+/** Pheromone-style trails between agents that touched the same file inside the collision window */
+export function drawCollisions(ctx: CanvasRenderingContext2D, collisions: CanvasCollision[], agents: Map<string, Agent>, time: number) {
+  for (const c of collisions) {
+    const nodes = c.agents.map(n => agents.get(n)).filter((a): a is Agent => !!a)
+    if (nodes.length < 2) continue
+    const alpha = 0.25 + 0.6 * c.freshness
+    const dash = (time * 40) % 24
+    ctx.save()
+    ctx.globalAlpha = alpha
+    ctx.strokeStyle = COLORS.waiting_permission
+    ctx.shadowColor = COLORS.waiting_permission
+    ctx.shadowBlur = 10
+    ctx.lineWidth = 2
+    ctx.setLineDash([10, 14])
+    ctx.lineDashOffset = -dash
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i + 1; j < nodes.length; j++) {
+        ctx.beginPath()
+        ctx.moveTo(nodes[i].x, nodes[i].y)
+        ctx.lineTo(nodes[j].x, nodes[j].y)
+        ctx.stroke()
+      }
+    }
+    // File label at the centroid
+    const cx = nodes.reduce((s, a) => s + a.x, 0) / nodes.length
+    const cy = nodes.reduce((s, a) => s + a.y, 0) / nodes.length
+    const label = `⚠ ${c.file.split(/[\\/]/).pop()}`
+    ctx.setLineDash([])
+    ctx.shadowBlur = 0
+    ctx.font = '10px ui-monospace, monospace'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    const w = ctx.measureText(label).width + 10
+    ctx.fillStyle = 'rgba(2, 6, 14, 0.85)'
+    ctx.fillRect(cx - w / 2, cy - 9, w, 18)
+    ctx.strokeStyle = COLORS.waiting_permission
+    ctx.lineWidth = 1
+    ctx.strokeRect(cx - w / 2, cy - 9, w, 18)
+    ctx.fillStyle = COLORS.waiting_permission
+    ctx.fillText(label, cx, cy)
+    ctx.restore()
+  }
+}

--- a/web/components/agent-visualizer/collision-strip.tsx
+++ b/web/components/agent-visualizer/collision-strip.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { COLORS } from '@/lib/colors'
+import { Z } from '@/lib/agent-types'
+import type { FileCollision, SessionInfo } from '@/lib/bridge-types'
+
+interface CollisionStripProps {
+  collisions: FileCollision[]
+  sessions: SessionInfo[]
+  selectedSessionId: string | null
+  onSelectSession: (id: string) => void
+}
+
+/** Cross-session same-file collisions, shown under the top bar. Click a session chip to jump to it. */
+export function CollisionStrip({ collisions, sessions, selectedSessionId, onSelectSession }: CollisionStripProps) {
+  const cross = collisions.filter(c => c.sessions.length > 1)
+  if (cross.length === 0) return null
+  const nameOf = (id: string) => sessions.find(x => x.id === id)?.label ?? id.slice(0, 8)
+  return (
+    <div className="absolute left-3 right-3 flex flex-wrap gap-2 font-mono text-[10px]" style={{ top: 44, zIndex: Z.info }}>
+      {cross.map(c => (
+        <div
+          key={c.file}
+          className="flex items-center gap-2 px-2 py-1 rounded-md"
+          style={{
+            background: 'rgba(255, 170, 51, 0.10)',
+            border: `1px solid ${COLORS.waiting_permission}66`,
+            color: COLORS.waiting_permission,
+            boxShadow: `0 0 12px rgba(255, 170, 51, 0.15)`,
+          }}
+          title={c.file}
+        >
+          <span>⚠ {c.file.split(/[\\/]/).pop()}</span>
+          {c.sessions.map(sid => (
+            <button
+              key={sid}
+              onClick={() => onSelectSession(sid)}
+              className="px-1.5 py-0.5 rounded"
+              style={{
+                background: sid === selectedSessionId ? COLORS.tabSelectedBg : COLORS.tabInactiveBg,
+                border: `1px solid ${sid === selectedSessionId ? COLORS.tabSelectedBorder : COLORS.tabInactiveBorder}`,
+                color: sid === selectedSessionId ? COLORS.holoBright : COLORS.textMuted,
+                maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}
+            >
+              {c.parties.filter(p => p.sessionId === sid).some(p => p.action === 'write') ? '✎ ' : '👁 '}
+              {nameOf(sid)}
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -23,6 +23,7 @@ import { COLORS } from "@/lib/colors"
 import { MOCK_DURATION } from "@/lib/mock-scenario"
 import { MessageFeedPanel } from "./message-feed-panel"
 import { TopBar } from "./top-bar"
+import { CollisionStrip } from "./collision-strip"
 import { useAudioEffects } from "@/hooks/use-audio-effects"
 
 export function AgentVisualizer() {
@@ -256,6 +257,23 @@ export function AgentVisualizer() {
 
   const isEmpty = agents.size === 0 && !bridge.useMockData
 
+  // Collisions touching this session: trails between the local agents involved
+  const allCollisions = useMemo(() => Array.from(bridge.collisions.values()), [bridge.collisions])
+  const canvasCollisions = useMemo(() => {
+    const sid = bridge.selectedSessionId
+    if (!sid) return []
+    const now = Date.now()
+    return allCollisions
+      .filter(c => c.sessions.includes(sid))
+      .map(c => ({
+        file: c.file,
+        agents: [...new Set(c.parties.filter(p => p.sessionId === sid).map(p => p.agent))],
+        crossSession: c.sessions.length > 1,
+        freshness: Math.max(0, 1 - (now - c.seenAt) / 90_000),
+      }))
+      .filter(c => c.agents.length >= 2)
+  }, [allCollisions, bridge.selectedSessionId])
+
   return (
     <OpenFileProvider value={bridge.isVSCode ? openFile : null}>
     <div className="h-screen w-screen relative overflow-hidden" style={{ background: COLORS.void }}>
@@ -287,6 +305,7 @@ export function AgentVisualizer() {
         onDiscoveryClick={selection.handleDiscoveryClick}
         selectedDiscoveryId={selection.selectedDiscoveryId}
         showCostOverlay={showCostOverlay}
+        collisions={canvasCollisions}
       />
 
       {/* Message feed panel (top-left) */}
@@ -397,6 +416,13 @@ export function AgentVisualizer() {
         timelineEntries={timelineEntries}
         currentTime={currentTime}
         onClose={() => setShowTimeline(false)}
+      />
+
+      <CollisionStrip
+        collisions={allCollisions}
+        sessions={bridge.sessions}
+        selectedSessionId={bridge.selectedSessionId}
+        onSelectSession={bridge.selectSession}
       />
 
       {/* Top bar: session tabs + info/controls */}

--- a/web/hooks/use-audio-effects.ts
+++ b/web/hooks/use-audio-effects.ts
@@ -4,6 +4,9 @@ import { AudioEngine } from '@/lib/audio-engine'
 import type { Agent, ToolCallNode } from '@/lib/agent-types'
 import { detectStateChanges } from '@/components/agent-visualizer/canvas/detect-state-changes'
 
+/** More simultaneous transitions than this means history replay, not live activity */
+const REPLAY_BURST_THRESHOLD = 3
+
 export function useAudioEffects(
   agents: Map<string, Agent>,
   toolCalls: Map<string, ToolCallNode>,
@@ -40,6 +43,9 @@ export function useAudioEffects(
     )
     prevAgentStatesRef.current = newAgentStates
     prevToolStatesRef.current = newToolStates
+
+    // A burst of transitions means history is being replayed, not live activity — stay quiet
+    if (transitions.length > REPLAY_BURST_THRESHOLD) return
 
     for (const t of transitions) {
       switch (t.kind) {

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { vscodeBridge, type ConnectionStatus, type AgentEvent, type SessionInfo } from '@/lib/vscode-bridge'
+import type { FileCollision } from '@/lib/bridge-types'
 import { SimulationEvent } from '@/lib/agent-types'
 
 interface BridgeHookResult {
@@ -33,6 +34,8 @@ interface BridgeHookResult {
   sessionsWithActivity: Set<string>
   /** Remove a session from the list */
   removeSession: (sessionId: string) => void
+  /** Live same-file collisions keyed by file path */
+  collisions: Map<string, FileCollision>
 }
 
 /**
@@ -43,6 +46,8 @@ interface BridgeHookResult {
  * Supports multi-session: events are buffered per-session so switching
  * sessions replays the correct event history.
  */
+const COLLISION_TTL_MS = 90 * 1000
+
 export function useVSCodeBridge(): BridgeHookResult {
   const [isVSCode, setIsVSCode] = useState(false)
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected')
@@ -62,6 +67,20 @@ export function useVSCodeBridge(): BridgeHookResult {
    *  Prevents the animation frame from processing events in the wrong simulation context. */
   const sessionSwitchPendingRef = useRef(false)
   const [sessionsWithActivity, setSessionsWithActivity] = useState<Set<string>>(new Set())
+  /** Live same-file collisions across all sessions, keyed by file; expire after COLLISION_TTL_MS */
+  const [collisions, setCollisions] = useState<Map<string, FileCollision>>(new Map())
+  useEffect(() => {
+    const t = setInterval(() => {
+      setCollisions(prev => {
+        const now = Date.now()
+        let changed = false
+        const next = new Map(prev)
+        for (const [k, c] of prev) if (now - c.seenAt > COLLISION_TTL_MS) { next.delete(k); changed = true }
+        return changed ? next : prev
+      })
+    }, 5000)
+    return () => clearInterval(t)
+  }, [])
 
   // Connect to standalone dev relay server via SSE when not in VS Code
   useEffect(() => {
@@ -112,6 +131,16 @@ export function useVSCodeBridge(): BridgeHookResult {
     // selectedSessionIdRef is updated synchronously (not via React state) so it's
     // always current even before React re-renders.
     const unsubEvent = bridge.onEvent((event: AgentEvent) => {
+      if (event.type === 'file_collision') {
+        // Global, not per-session: the same collision arrives once per involved session
+        const p = event.payload as { file: string; parties: FileCollision['parties']; sessions: string[] }
+        setCollisions(prev => {
+          const next = new Map(prev)
+          next.set(p.file, { file: p.file, parties: p.parties, sessions: p.sessions, seenAt: Date.now() })
+          return next
+        })
+        return
+      }
       const simEvent: SimulationEvent = {
         time: event.time,
         type: event.type as SimulationEvent['type'],
@@ -315,5 +344,6 @@ export function useVSCodeBridge(): BridgeHookResult {
     getSessionEventCount,
     sessionsWithActivity,
     removeSession,
+    collisions,
   }
 }

--- a/web/lib/agent-types.ts
+++ b/web/lib/agent-types.ts
@@ -161,6 +161,7 @@ export interface SimulationEvent {
     | 'subagent_dispatch'
     | 'subagent_return'
     | 'permission_requested'
+    | 'file_collision'
   payload: Record<string, unknown>
   sessionId?: string
 }

--- a/web/lib/bridge-types.ts
+++ b/web/lib/bridge-types.ts
@@ -21,4 +21,13 @@ export interface SessionInfo {
   lastActivityTime: number
 }
 
+/** A same-file collision between agents (same or different sessions), as reported by the backend */
+export interface FileCollision {
+  file: string
+  parties: Array<{ sessionId: string; agent: string; action: 'read' | 'write'; wall: number }>
+  sessions: string[]
+  /** browser receipt time, for expiry */
+  seenAt: number
+}
+
 export type ConnectionStatus = 'connected' | 'disconnected' | 'watching'


### PR DESCRIPTION
Stacked on #79 (backfill), which it needs for the replay-aware clock.

With many sessions running in parallel, the one-canvas-per-session model cannot show the one thing that actually bites: two agents working on the same file at the same time.

- A process-wide `FileCollisionIndex` records every file-touching tool call per normalized path in a 90s sliding window. When two distinct parties (session + agent) touch the same file and at least one of them writes, a `file_collision` event is emitted to every involved session. Read-vs-read is deliberately ignored (agents grepping the same config all day is noise).
- **Same session**: a dashed, glowing trail between the involved agent nodes with the file name at the centroid, fading over the window.
- **Different sessions**: a strip under the top bar naming the file and the sessions (✎ wrote, 👁 read); click a session to jump to it.
- Unit tests for the index in `scripts/file-collisions.test.ts`.

https://claude.ai/code/session_01AGs5TZo6yxv7NHARHawyJf