### PR TITLE
feat: dead-letter panel for failed tool calls, and context compaction relic

### DIFF
--- a/extension/src/protocol.ts
+++ b/extension/src/protocol.ts
@@ -19,6 +19,7 @@ export type AgentEventType =
   | 'subagent_dispatch'
   | 'subagent_return'
   | 'permission_requested'
+  | 'context_compacted'
   | 'error'
 
 export interface AgentEvent {

--- a/extension/src/transcript-parser.ts
+++ b/extension/src/transcript-parser.ts
@@ -28,6 +28,9 @@ import { createLogger } from './logger'
 
 const log = createLogger('TranscriptParser')
 
+/** First line Claude Code writes as the user message after a compaction */
+const COMPACTION_PREFIX = 'This session is being continued from a previous conversation'
+
 export interface TranscriptParserDelegate {
   emit(event: AgentEvent, sessionId?: string): void
   elapsed(sessionId?: string): number
@@ -161,6 +164,7 @@ export class TranscriptParser {
     if (typeof msg.content === 'string' && msg.content.trim()) {
       if (role === 'user' || role === 'human') {
         const text = msg.content.trim()
+        if (session && text.startsWith(COMPACTION_PREFIX)) this.handleCompaction(text, agentName, session, sessionId)
         // Skip system-injected context (continuation summaries, IDE context, etc.)
         if (!this.isSystemInjectedContent(text)) {
           const hash = entry.uuid ? `user:${entry.uuid}` : `user:${text.slice(0, HASH_PREFIX_MAX)}`
@@ -261,6 +265,24 @@ export class TranscriptParser {
         role: 'thinking',
         content: thinking ? thinking.slice(0, MESSAGE_MAX) : REDACTED_THINKING_LABEL,
       },
+    }, sessionId)
+  }
+
+  /** Context compaction: the old context is gone, a summary ("relic") takes its place */
+  private handleCompaction(text: string, agentName: string, session: WatchedSession, sessionId?: string): void {
+    const before = session.contextBreakdown.systemPrompt + session.contextBreakdown.userMessages
+      + session.contextBreakdown.toolResults + session.contextBreakdown.reasoning + session.contextBreakdown.subagentResults
+    const summaryStart = text.indexOf('Summary:')
+    const summary = (summaryStart >= 0 ? text.slice(summaryStart + 'Summary:'.length) : text).trim()
+    const summaryTokens = estimateTokensFromText(text)
+    session.contextBreakdown = {
+      systemPrompt: session.contextBreakdown.systemPrompt,
+      userMessages: summaryTokens, toolResults: 0, reasoning: 0, subagentResults: 0,
+    }
+    this.delegate.emit({
+      time: this.delegate.elapsed(sessionId),
+      type: 'context_compacted',
+      payload: { agent: agentName, before, after: session.contextBreakdown.systemPrompt + summaryTokens, relic: summary.slice(0, MESSAGE_MAX) },
     }, sessionId)
   }
 

--- a/web/components/agent-visualizer/dead-letter-panel.tsx
+++ b/web/components/agent-visualizer/dead-letter-panel.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useMemo } from 'react'
+import { COLORS } from '@/lib/colors'
+import { Z, type ToolCallNode } from '@/lib/agent-types'
+import { formatTokens } from '@/lib/utils'
+import { PanelHeader, SlidingPanel } from './shared-ui'
+
+interface DeadLetterPanelProps {
+  visible: boolean
+  toolCalls: Map<string, ToolCallNode>
+  onClose: () => void
+  onSelectToolCall?: (id: string) => void
+}
+
+interface DeadLetter {
+  call: ToolCallNode
+  /** tokens spent on later calls of the same tool+args by the same agent, i.e. what the failure cost to retry */
+  retryCost: number
+  retries: number
+}
+
+/** Failed tool calls, shunted off the main graph into a siding, with what each failure cost in retries. */
+export function DeadLetterPanel({ visible, toolCalls, onClose, onSelectToolCall }: DeadLetterPanelProps) {
+  const letters = useMemo<DeadLetter[]>(() => {
+    const all = Array.from(toolCalls.values())
+    return all
+      .filter(tc => tc.state === 'error')
+      .map(call => {
+        const later = all.filter(o => o.id !== call.id && o.agentId === call.agentId && o.toolName === call.toolName && o.args === call.args && o.startTime > call.startTime)
+        return { call, retries: later.length, retryCost: later.reduce((s, o) => s + (o.tokenCost ?? 0), 0) }
+      })
+      .sort((a, b) => b.call.startTime - a.call.startTime)
+  }, [toolCalls])
+
+  if (!visible) return null
+  const totalRetryCost = letters.reduce((s, l) => s + l.retryCost, 0)
+
+  return (
+    <SlidingPanel visible={visible} position={{ top: 48, right: 12 }} zIndex={Z.sidePanel} width={300}>
+      <div className="glass-card relative">
+        <PanelHeader onClose={onClose}>
+          <span className="text-[10px] font-mono tracking-wider" style={{ color: COLORS.textPrimary }}>
+            DEAD LETTERS
+          </span>
+          <span className="text-[9px] font-mono" style={{ color: COLORS.textMuted }}>
+            {letters.length} failed · {formatTokens(totalRetryCost)} spent retrying
+          </span>
+        </PanelHeader>
+
+        <div className="space-y-1 max-h-[340px] overflow-y-auto">
+          {letters.length === 0 && (
+            <div className="text-[9px] font-mono py-2 text-center" style={{ color: COLORS.textMuted }}>
+              No failed tool calls
+            </div>
+          )}
+          {letters.map(({ call, retries, retryCost }) => (
+            <div
+              key={call.id}
+              className="rounded px-2 py-1.5 hover:brightness-125 cursor-pointer"
+              style={{ background: 'rgba(30, 10, 15, 0.5)', border: `1px solid ${COLORS.error}30` }}
+              onClick={() => onSelectToolCall?.(call.id)}
+              title={call.errorMessage}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[9px] font-mono truncate" style={{ color: COLORS.error }}>
+                  {call.toolName} <span style={{ color: COLORS.textMuted }}>{call.args}</span>
+                </span>
+                <span className="text-[9px] font-mono flex-shrink-0" style={{ color: COLORS.textMuted }}>{call.agentId}</span>
+              </div>
+              {call.errorMessage && (
+                <div className="text-[9px] font-mono mt-0.5 truncate" style={{ color: COLORS.textMuted, opacity: 0.8 }}>
+                  {call.errorMessage.split('\n')[0]}
+                </div>
+              )}
+              <div className="text-[9px] font-mono mt-0.5" style={{ color: retries > 0 ? COLORS.tool : COLORS.textMuted }}>
+                {retries > 0 ? `${retries} retr${retries === 1 ? 'y' : 'ies'} · ${formatTokens(retryCost)} tokens` : 'not retried'}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </SlidingPanel>
+  )
+}

--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -23,6 +23,7 @@ import { COLORS } from "@/lib/colors"
 import { MOCK_DURATION } from "@/lib/mock-scenario"
 import { MessageFeedPanel } from "./message-feed-panel"
 import { TopBar } from "./top-bar"
+import { DeadLetterPanel } from "./dead-letter-panel"
 import { useAudioEffects } from "@/hooks/use-audio-effects"
 
 export function AgentVisualizer() {
@@ -69,9 +70,11 @@ export function AgentVisualizer() {
   const [showTimeline, setShowTimeline] = useState(false)
   const [showFileAttention, setShowFileAttention] = useState(false)
   const [showTranscript, setShowTranscript] = useState(false)
+  const [showDeadLetters, setShowDeadLetters] = useState(false)
 
   // Mutually exclusive panel toggling — opening one closes the others
-  const toggleExclusivePanel = useCallback((panel: 'files' | 'transcript' | 'cost') => {
+  const toggleExclusivePanel = useCallback((panel: 'files' | 'transcript' | 'cost' | 'dead') => {
+    setShowDeadLetters(prev => panel === 'dead' ? !prev : false)
     setShowFileAttention(prev => panel === 'files' ? !prev : false)
     setShowTranscript(prev => panel === 'transcript' ? !prev : false)
     setShowCostOverlay(prev => panel === 'cost' ? !prev : false)
@@ -255,6 +258,7 @@ export function AgentVisualizer() {
   }, [bridge])
 
   const isEmpty = agents.size === 0 && !bridge.useMockData
+  const deadLetterCount = useMemo(() => { let n = 0; for (const tc of toolCalls.values()) if (tc.state === 'error') n++; return n }, [toolCalls])
 
   return (
     <OpenFileProvider value={bridge.isVSCode ? openFile : null}>
@@ -376,6 +380,13 @@ export function AgentVisualizer() {
       />
 
       {/* File attention panel (slide-in from right) */}
+      <DeadLetterPanel
+        visible={showDeadLetters}
+        toolCalls={toolCalls}
+        onClose={() => setShowDeadLetters(false)}
+        onSelectToolCall={selection.handleToolCallClick}
+      />
+
       <FileAttentionPanel
         visible={showFileAttention}
         fileAttention={fileAttention}
@@ -412,6 +423,8 @@ export function AgentVisualizer() {
         totalTokens={totalTokens}
         showFileAttention={showFileAttention}
         showTranscript={showTranscript}
+        showDeadLetters={showDeadLetters}
+        deadLetterCount={deadLetterCount}
         showCostOverlay={showCostOverlay}
         showTimeline={showTimeline}
         isMuted={isMuted}

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -95,7 +95,9 @@ export interface TopBarProps {
   showCostOverlay: boolean
   showTimeline: boolean
   isMuted: boolean
-  onTogglePanel: (panel: 'files' | 'transcript' | 'cost') => void
+  onTogglePanel: (panel: 'files' | 'transcript' | 'cost' | 'dead') => void
+  showDeadLetters: boolean
+  deadLetterCount: number
   onToggleTimeline: () => void
   onToggleMute: () => void
 }
@@ -106,6 +108,7 @@ export const TopBar = memo(function TopBar({
   isVSCode, connectionStatus,
   agentCount, totalTokens,
   showFileAttention, showTranscript, showCostOverlay, showTimeline, isMuted,
+  showDeadLetters, deadLetterCount,
   onTogglePanel, onToggleTimeline, onToggleMute,
 }: TopBarProps) {
   return (
@@ -144,6 +147,14 @@ export const TopBar = memo(function TopBar({
         }}>
           <ToggleButton active={showFileAttention} onClick={() => onTogglePanel('files')} style={{ background: showFileAttention ? undefined : 'transparent', border: 'none' }}>Files</ToggleButton>
           <ToggleButton active={showTranscript} onClick={() => onTogglePanel('transcript')} style={{ background: showTranscript ? undefined : 'transparent', border: 'none' }}>Chat</ToggleButton>
+          <ToggleButton
+            active={showDeadLetters}
+            onClick={() => onTogglePanel('dead')}
+            activeColor={{ bg: 'rgba(255, 85, 102, 0.18)', text: COLORS.error }}
+            style={{ background: showDeadLetters ? undefined : 'transparent', border: 'none', color: deadLetterCount > 0 && !showDeadLetters ? COLORS.error : undefined }}
+          >
+            ✕ {deadLetterCount}
+          </ToggleButton>
           <ToggleButton
             active={showCostOverlay}
             onClick={() => onTogglePanel('cost')}

--- a/web/hooks/simulation/handle-message-events.ts
+++ b/web/hooks/simulation/handle-message-events.ts
@@ -1,7 +1,10 @@
 import type { ContextBreakdown } from '@/lib/agent-types'
 import type { ConversationMessage } from './types'
 import { appendConversation, asString, asNumber, LABEL_LEN_NAME, LABEL_LEN_TASK, LABEL_LEN_BUBBLE, MAX_BUBBLES } from './types'
-import type { MutableEventState } from './process-event'
+import type { MutableEventState, ProcessEventContext } from './process-event'
+import { pushTimelineBlock } from './process-event'
+import { COLORS } from '@/lib/colors'
+import { formatTokens } from '@/lib/utils'
 
 export function handleMessage(
   payload: Record<string, unknown>,
@@ -80,4 +83,26 @@ export function handleContextUpdate(
       state: agent.state === 'complete' ? 'complete' : 'thinking'
     })
   }
+}
+
+/** Context compaction: the boss died, a relic (the summary) drops. Marks the timeline and leaves the relic in the transcript. */
+export function handleContextCompacted(
+  payload: Record<string, unknown>,
+  currentTime: number,
+  state: MutableEventState,
+  ctx: ProcessEventContext,
+): void {
+  const agentName = asString(payload.agent)
+  const before = asNumber(payload.before)
+  const after = asNumber(payload.after)
+  const relic = asString(payload.relic)
+  const agent = state.agents.get(agentName)
+  if (agent) {
+    const bubble = { text: `⟲ Context compacted: ${formatTokens(before)} → ${formatTokens(after)}`, time: currentTime, role: 'assistant' as const }
+    const newBubbles = [...agent.messageBubbles, bubble]
+    state.agents.set(agentName, { ...agent, messageBubbles: newBubbles.length > MAX_BUBBLES ? newBubbles.slice(-MAX_BUBBLES) : newBubbles })
+  }
+  const entry = state.timelineEntries.get(agentName)
+  if (entry) pushTimelineBlock(entry, currentTime, { type: 'idle', label: `Compacted ${formatTokens(before)} → ${formatTokens(after)}`, color: COLORS.paused, endTime: currentTime + 1 }, ctx)
+  appendConversation(state.conversations, agentName, { type: 'assistant', content: `⟲ CONTEXT COMPACTED (${formatTokens(before)} → ${formatTokens(after)})\n\nRelic:\n${relic}`, timestamp: currentTime })
 }

--- a/web/hooks/simulation/process-event.ts
+++ b/web/hooks/simulation/process-event.ts
@@ -9,7 +9,7 @@ import {
 import type { SimulationState, ConversationMessage } from './types'
 import { handleAgentSpawn, handleAgentComplete, handleAgentIdle, handlePermissionRequested, handleModelDetected } from './handle-agent-events'
 import { handleToolCallStart, handleToolCallEnd } from './handle-tool-events'
-import { handleMessage, handleContextUpdate } from './handle-message-events'
+import { handleMessage, handleContextUpdate, handleContextCompacted } from './handle-message-events'
 import { handleSubagentDispatch, handleSubagentReturn } from './handle-subagent-events'
 
 export interface ProcessEventContext {
@@ -82,6 +82,7 @@ export function processEvent(event: SimulationEvent, prev: SimulationState, ctx:
         case 'subagent_dispatch': handleSubagentDispatch(event.payload, prev.currentTime, state); break
         case 'subagent_return':   handleSubagentReturn(event.payload, prev.currentTime, state); break
         case 'permission_requested': handlePermissionRequested(event.payload, prev.currentTime, state, ctx); break
+        case 'context_compacted':  handleContextCompacted(event.payload, prev.currentTime, state, ctx); break
       }
 
       // Stabilize references for unchanged collections to prevent

--- a/web/lib/agent-types.ts
+++ b/web/lib/agent-types.ts
@@ -161,6 +161,7 @@ export interface SimulationEvent {
     | 'subagent_dispatch'
     | 'subagent_return'
     | 'permission_requested'
+    | 'context_compacted'
   payload: Record<string, unknown>
   sessionId?: string
 }


### PR DESCRIPTION
Two small things that give shape to events that are currently invisible.

**Dead letters.** A panel (`✕ N` in the top bar's panel group) lists every failed tool call: agent, tool, args, first line of the error, and what the failure cost, i.e. how many later identical calls the same agent made and their token cost. Clicking a row selects the tool call on the canvas. Derived entirely from the existing `toolCalls` state, no backend change.

**Compaction relic.** The parser recognizes the continuation summary Claude Code writes as the first user message after a compaction. It resets the session's context accounting to system prompt + summary (the old context really is gone) and emits a `context_compacted` event. The orchestrator shows a bubble with before → after tokens, the timeline gets a 'Compacted' block, and the transcript keeps the summary text as the relic.

https://claude.ai/code/session_01AGs5TZo6yxv7NHARHawyJf